### PR TITLE
UselessPrivatePropertyNullabilityRule: drop extension provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     ],
     "require": {
         "nikic/php-parser": "^4.13.2",
-        "phpstan/phpstan": "^1.5.6"
+        "phpstan/phpstan": "1.8.x-dev"
     },
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "^10.3.0",

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     ],
     "require": {
         "nikic/php-parser": "^4.13.2",
-        "phpstan/phpstan": "1.8.x-dev"
+        "phpstan/phpstan": "^1.8.1"
     },
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "^10.3.0",

--- a/src/Rule/UselessPrivatePropertyNullabilityRule.php
+++ b/src/Rule/UselessPrivatePropertyNullabilityRule.php
@@ -10,7 +10,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassPropertiesNode;
 use PHPStan\Node\Property\PropertyWrite;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -22,15 +21,6 @@ use ShipMonk\PHPStan\Visitor\ClassPropertyAssignmentVisitor;
  */
 class UselessPrivatePropertyNullabilityRule implements Rule
 {
-
-    private ReadWritePropertiesExtensionProvider $extensionProvider;
-
-    public function __construct(
-        ReadWritePropertiesExtensionProvider $extensionProvider
-    )
-    {
-        $this->extensionProvider = $extensionProvider;
-    }
 
     public function getNodeType(): string
     {
@@ -80,7 +70,7 @@ class UselessPrivatePropertyNullabilityRule implements Rule
             }
         }
 
-        [$uninitializedProperties] = $node->getUninitializedProperties($scope, $this->getConstructors($classReflection), $this->extensionProvider->getExtensions()); // @phpstan-ignore-line ignore bc promise
+        [$uninitializedProperties] = $node->getUninitializedProperties($scope, $this->getConstructors($classReflection));
 
         $errors = [];
 

--- a/tests/Rule/UselessPrivatePropertyNullabilityRuleTest.php
+++ b/tests/Rule/UselessPrivatePropertyNullabilityRuleTest.php
@@ -2,7 +2,6 @@
 
 namespace ShipMonk\PHPStan\Rule;
 
-use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
 use function array_merge;
@@ -15,7 +14,7 @@ class UselessPrivatePropertyNullabilityRuleTest extends RuleTestCase
 
     protected function getRule(): Rule
     {
-        return new UselessPrivatePropertyNullabilityRule(self::getContainer()->getByType(ReadWritePropertiesExtensionProvider::class));
+        return new UselessPrivatePropertyNullabilityRule();
     }
 
     /**


### PR DESCRIPTION
Solution from https://github.com/phpstan/phpstan-src/pull/1480#issuecomment-1169960148