### PR TITLE
ForbidAssignmentNotMatchingVarDocRule: fix check-shape-only with iterable

### DIFF
--- a/src/Rule/ForbidAssignmentNotMatchingVarDocRule.php
+++ b/src/Rule/ForbidAssignmentNotMatchingVarDocRule.php
@@ -10,6 +10,7 @@ use PHPStan\PhpDoc\Tag\VarTag;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\FileTypeMapper;
+use PHPStan\Type\IterableType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeTraverser;
@@ -102,7 +103,7 @@ class ForbidAssignmentNotMatchingVarDocRule implements Rule
     private function weakenTypeToKeepShapeOnly(Type $type): Type
     {
         return TypeTraverser::map($type, static function (Type $type, callable $traverse): Type {
-            if ($type instanceof ArrayType) {
+            if ($type instanceof ArrayType || $type instanceof IterableType) {
                 return $traverse($type); // keep array shapes, but forget all inner types
             }
 

--- a/tests/Rule/data/ForbidAssignmentNotMatchingVarDocRule/code.php
+++ b/tests/Rule/data/ForbidAssignmentNotMatchingVarDocRule/code.php
@@ -53,6 +53,9 @@ class ExampleClass extends ExampleClassParent
         /** @var array{id: string, value: string} $var check-shape-only */
         $var = $this->returnArrayShape();
 
+        /** @var iterable<array{invalid: string}> $var check-shape-only */
+        $var = $this->returnIterableWithArrayShape(); // error: Invalid var phpdoc of $var. Cannot assign iterable<array{id: mixed, value: mixed}> to iterable<array{invalid: string}>
+
 
         /** @var self $var */
         $var = $this->returnSelf();
@@ -127,11 +130,11 @@ class ExampleClass extends ExampleClassParent
     }
 
     /**
-     * @return iterable{ id: int, value: string }
+     * @return iterable<array{ id: int, value: string }>
      */
-    public function returnIterableWithShape(): iterable
+    public function returnIterableWithArrayShape(): iterable
     {
-        return ['id' => 1, 'value' => 'foo'];
+        return [['id' => 1, 'value' => 'foo']];
     }
 
     public function returnInt(): int


### PR DESCRIPTION
…ables