### PR TITLE
ClassPropertyAssignmentVisitor: drop useless AST cycle

### DIFF
--- a/src/Rule/UselessPrivatePropertyNullabilityRule.php
+++ b/src/Rule/UselessPrivatePropertyNullabilityRule.php
@@ -4,7 +4,6 @@ namespace ShipMonk\PHPStan\Rule;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\ConstFetch;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassPropertiesNode;
@@ -56,14 +55,14 @@ class UselessPrivatePropertyNullabilityRule implements Rule
 
             $propertyName = $fetch->name->toString();
 
-            /** @var Assign|null $assignment */
-            $assignment = $fetch->getAttribute(ClassPropertyAssignmentVisitor::ASSIGNMENT);
+            /** @var Expr|null $assignedExpr */
+            $assignedExpr = $fetch->getAttribute(ClassPropertyAssignmentVisitor::ASSIGNED_EXPR);
 
-            if ($assignment === null) { // cases like object->array[] = value etc
+            if ($assignedExpr === null) { // cases like object->array[] = value etc
                 continue;
             }
 
-            $assignedType = $propertyUsage->getScope()->getType($assignment->expr);
+            $assignedType = $propertyUsage->getScope()->getType($assignedExpr);
 
             if (TypeCombinator::containsNull($assignedType)) {
                 $nullabilityNeeded[$propertyName] = true;

--- a/src/Visitor/ClassPropertyAssignmentVisitor.php
+++ b/src/Visitor/ClassPropertyAssignmentVisitor.php
@@ -13,7 +13,7 @@ use function count;
 class ClassPropertyAssignmentVisitor extends NodeVisitorAbstract
 {
 
-    public const ASSIGNMENT = ShipMonkNodeVisitor::NODE_ATTRIBUTE_PREFIX . 'assignment';
+    public const ASSIGNED_EXPR = ShipMonkNodeVisitor::NODE_ATTRIBUTE_PREFIX . 'assignment';
 
     /**
      * @var Node[]
@@ -39,7 +39,7 @@ class ClassPropertyAssignmentVisitor extends NodeVisitorAbstract
                 $parent instanceof Assign
                 && ($node instanceof PropertyFetch || $node instanceof StaticPropertyFetch)
             ) {
-                $node->setAttribute(self::ASSIGNMENT, $parent);
+                $node->setAttribute(self::ASSIGNED_EXPR, $parent->expr);
             }
 
             $this->stack[] = $node;


### PR DESCRIPTION
Before:
```
Assign <-> var (PropFetch)
        -> expr (Expr)
```

Now:
```
Assign -> var (PropFetch)
             ↓
       -> expr (Expr)
```