### PR TITLE
Fix UselessPrivatePropertyNullabilityRule false-positive for promoted properties

### DIFF
--- a/src/Rule/UselessPrivatePropertyNullabilityRule.php
+++ b/src/Rule/UselessPrivatePropertyNullabilityRule.php
@@ -74,7 +74,7 @@ class UselessPrivatePropertyNullabilityRule implements Rule
         $errors = [];
 
         foreach ($node->getProperties() as $property) {
-            $shouldBeChecked = $property->isPrivate() || $property->isReadOnly();
+            $shouldBeChecked = ($property->isPrivate() || $property->isReadOnly()) && !$property->isPromoted();
 
             if (!$shouldBeChecked) {
                 continue;

--- a/tests/Rule/data/UselessPrivatePropertyNullabilityRule/code.php
+++ b/tests/Rule/data/UselessPrivatePropertyNullabilityRule/code.php
@@ -26,7 +26,8 @@ class ExampleClass
         int $isPrivate,
         int $isPrivateWithConditionalAssignment,
         int $isPrivateWithDefaultNull,
-        int $isPrivateWithDefaultNotNull
+        int $isPrivateWithDefaultNotNull,
+        private ?int $isPrivatePromoted
     ) {
         $this->isPublic = $isPublic;
         $this->isProtected = $isProtected;


### PR DESCRIPTION
When the property is promoted, null value can be assigned to it when an instance is created so it shouldn't be reported as never having null value.