### PR TITLE
Match can contain only assignments

### DIFF
--- a/src/Rule/ForbidUnusedMatchResultRule.php
+++ b/src/Rule/ForbidUnusedMatchResultRule.php
@@ -3,6 +3,7 @@
 namespace ShipMonk\PHPStan\Rule;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Match_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
@@ -34,7 +35,7 @@ class ForbidUnusedMatchResultRule implements Rule
         foreach ($node->arms as $arm) {
             $armType = $scope->getType($arm->body);
 
-            if (!$armType instanceof VoidType && !$armType instanceof NeverType) {
+            if (!$armType instanceof VoidType && !$armType instanceof NeverType && !$arm->body instanceof Assign) {
                 $returnedTypes[] = $armType;
             }
         }

--- a/tests/Rule/data/ForbidUnusedMatchResultRule/code.php
+++ b/tests/Rule/data/ForbidUnusedMatchResultRule/code.php
@@ -41,6 +41,11 @@ class Clazz {
             };
         } catch (\Throwable $e) {}
 
+        match ($int) {
+            0 => $a = 'x',
+            1 => $b = 'y',
+        };
+
         return match ($bool) {
             false => 1,
             true => 2,
@@ -63,6 +68,11 @@ class Clazz {
             0 => new LogicException(),
             1 => new RuntimeException(),
             default => new Exception(),
+        };
+
+        match ($int) { // error: Unused match result detected, possible returns: string
+            0 => $a = 'x',
+            1 => 'y',
         };
     }
 


### PR DESCRIPTION
Match can contain only assignments like this:

```php
        match ($int) {
            0 => $a = 'x',
            1 => $b = 'y',
        };
```

Then is not necessary to trigger `ForbidUnusedMatchResultRule`.