### PR TITLE
EnforceNativeReturnTypehintRule: try narrowing enforcement

### DIFF
--- a/tests/Rule/EnforceNativeReturnTypehintRuleTest.php
+++ b/tests/Rule/EnforceNativeReturnTypehintRuleTest.php
@@ -23,6 +23,7 @@ class EnforceNativeReturnTypehintRuleTest extends RuleTestCase
             self::getContainer()->getByType(FileTypeMapper::class),
             $this->phpVersion,
             true,
+            true,
         );
     }
 

--- a/tests/Rule/data/EnforceNativeReturnTypehintRule/code-81.php
+++ b/tests/Rule/data/EnforceNativeReturnTypehintRule/code-81.php
@@ -18,13 +18,10 @@ class DeductFromPhpDocs {
     public function doNotReportWithTypehint1(): array {}
 
     /** @return int */
-    public function doNotReportWithTypehint2(): never {}
+    public function doNotReportWithTypehint2(): int {}
 
-    /** @return int */
+    /** @return mixed */
     public function doNotReportWithTypehint3(): mixed {}
-
-    /** @return float */
-    public function doNotReportWithTypehint4(): int {}
 
     /** @return list<string> */
     public function requireArray() {} // error: Missing native return typehint array
@@ -84,7 +81,7 @@ class DeductFromPhpDocs {
     public function requireVoid() {} // error: Missing native return typehint void
 
     /** @return null */
-    public function requireNullVoid() {}
+    public function requireNull() {}
 
     /** @return never */
     public function requireNever() {} // error: Missing native return typehint never
@@ -223,6 +220,61 @@ class DeductFromReturnStatements {
         return function () { // error: Missing native return typehint int
             return 1;
         };
+    }
+
+}
+
+class EnforceNarrowerTypehint {
+
+    public function requireIterableObject(): iterable // error: Native return typehint is iterable, but can be narrowed to \ArrayObject
+    {
+        return new \ArrayObject();
+    }
+
+    public function requireCallableObject(): callable // error: Native return typehint is callable, but can be narrowed to \EnforceNativeReturnTypehintRule81\CallableObject
+    {
+        return new CallableObject();
+    }
+
+    public function requireString(): mixed // error: Native return typehint is mixed, but can be narrowed to string
+    {
+        return self::class;
+    }
+
+    public function requireClosure(): callable // error: Native return typehint is callable, but can be narrowed to \Closure
+    {
+        return function (): int {
+            return 1;
+        };
+    }
+
+    public function requireChild(): \Throwable // error: Native return typehint is \Throwable, but can be narrowed to \LogicException
+    {
+        return new \LogicException();
+    }
+
+    /**
+     * @return \LogicException|\RuntimeException
+     */
+    public function requireUnion(): object // error: Native return typehint is object, but can be narrowed to \LogicException|\RuntimeException
+    {
+
+    }
+
+    public function requireNever(): void // error: Native return typehint is void, but can be narrowed to never
+    {
+        throw new \LogicException();
+    }
+
+    public function returnThis(): self // error: Native return typehint is self, but can be narrowed to static
+    {
+        return $this;
+    }
+
+
+    public function requireNullableString2(?string $out): mixed // error: Native return typehint is mixed, but can be narrowed to ?string
+    {
+        return $out;
     }
 
 }


### PR DESCRIPTION
- attempt, but when tested on big codebase, there are plenty problematic situations, like
   - typehint says interface, but we return multiple children -> forcing to use union of them
   - anon classes returned (fixable)
   - invalid (old) phpdocs like Generator|mixed[] breaking proper suggestion -> forcing generinc iterable in this example
   - invalid phpdocs (this is not reported by phpstan) like [this](https://github.com/shipmonk-rnd/phpstan-rules/blob/f6c165b/src/Visitor/ClassPropertyAssignmentVisitor.php#L25) -> forcing wrong native typehint