### PR TITLE
EnforceNativeReturnTypehintRule: resource not typehintable & fix self|self

### DIFF
--- a/src/Rule/EnforceNativeReturnTypehintRule.php
+++ b/src/Rule/EnforceNativeReturnTypehintRule.php
@@ -26,7 +26,6 @@ use PHPStan\Type\NeverType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\ObjectWithoutClassType;
-use PHPStan\Type\ResourceType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -144,8 +143,6 @@ class EnforceNativeReturnTypehintRule implements Rule
             } else {
                 $typeHint = 'bool';
             }
-        } elseif ((new ResourceType())->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {
-            $typeHint = 'resource';
         } elseif ((new IntegerType())->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {
             $typeHint = 'int';
         } elseif ((new FloatType())->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {

--- a/src/Rule/EnforceNativeReturnTypehintRule.php
+++ b/src/Rule/EnforceNativeReturnTypehintRule.php
@@ -281,6 +281,10 @@ class EnforceNativeReturnTypehintRule implements Rule
                 return null;
             }
 
+            if (in_array($subtypeHint, $typehintParts, true)) {
+                continue;
+            }
+
             $typehintParts[] = $wrap ? "($subtypeHint)" : $subtypeHint;
         }
 
@@ -314,6 +318,10 @@ class EnforceNativeReturnTypehintRule implements Rule
 
             if ($subtypeHint === null) {
                 return null;
+            }
+
+            if (in_array($subtypeHint, $typehintParts, true)) {
+                continue;
             }
 
             $typehintParts[] = $wrap ? "($subtypeHint)" : $subtypeHint;

--- a/tests/Rule/EnforceNativeReturnTypehintRuleTest.php
+++ b/tests/Rule/EnforceNativeReturnTypehintRuleTest.php
@@ -6,6 +6,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\FileTypeMapper;
 use ShipMonk\PHPStan\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<EnforceNativeReturnTypehintRule>
@@ -24,6 +25,16 @@ class EnforceNativeReturnTypehintRuleTest extends RuleTestCase
             $this->phpVersion,
             true,
         );
+    }
+
+    public function testEnum(): void
+    {
+        if (PHP_VERSION_ID < 80_100) {
+            self::markTestSkipped('Requires PHP 8.1');
+        }
+
+        $this->phpVersion = self::getContainer()->getByType(PhpVersion::class);
+        $this->analyseFile(__DIR__ . '/data/EnforceNativeReturnTypehintRule/code-enum.php');
     }
 
     public function testPhp82(): void

--- a/tests/Rule/data/EnforceNativeReturnTypehintRule/code-80.php
+++ b/tests/Rule/data/EnforceNativeReturnTypehintRule/code-80.php
@@ -177,7 +177,7 @@ class DeductFromReturnStatements {
         return $this;
     }
 
-    public function returnResource() // error: Missing native return typehint resource|bool
+    public function returnResource()
     {
         return fopen('php://memory');
     }

--- a/tests/Rule/data/EnforceNativeReturnTypehintRule/code-81.php
+++ b/tests/Rule/data/EnforceNativeReturnTypehintRule/code-81.php
@@ -286,14 +286,3 @@ class TraitUser2 {
         return new \LogicException();
     }
 }
-
-enum MyBoolean: string
-{
-    case True = 'true';
-    case False = 'false';
-
-    public static function createFromBool(bool $boolValue) // error: Missing native return typehint self
-    {
-        return $boolValue ? self::True : self::False;
-    }
-}

--- a/tests/Rule/data/EnforceNativeReturnTypehintRule/code-81.php
+++ b/tests/Rule/data/EnforceNativeReturnTypehintRule/code-81.php
@@ -178,7 +178,7 @@ class DeductFromReturnStatements {
         return $this;
     }
 
-    public function returnResource() // error: Missing native return typehint resource|bool
+    public function returnResource()
     {
         return fopen('php://memory');
     }

--- a/tests/Rule/data/EnforceNativeReturnTypehintRule/code-81.php
+++ b/tests/Rule/data/EnforceNativeReturnTypehintRule/code-81.php
@@ -286,3 +286,14 @@ class TraitUser2 {
         return new \LogicException();
     }
 }
+
+enum MyBoolean: string
+{
+    case True = 'true';
+    case False = 'false';
+
+    public static function createFromBool(bool $boolValue) // error: Missing native return typehint self
+    {
+        return $boolValue ? self::True : self::False;
+    }
+}

--- a/tests/Rule/data/EnforceNativeReturnTypehintRule/code-82.php
+++ b/tests/Rule/data/EnforceNativeReturnTypehintRule/code-82.php
@@ -285,14 +285,3 @@ class TraitUser2 {
         return new \LogicException();
     }
 }
-
-enum MyBoolean: string
-{
-    case True = 'true';
-    case False = 'false';
-
-    public static function createFromBool(bool $boolValue) // error: Missing native return typehint self
-    {
-        return $boolValue ? self::True : self::False;
-    }
-}

--- a/tests/Rule/data/EnforceNativeReturnTypehintRule/code-82.php
+++ b/tests/Rule/data/EnforceNativeReturnTypehintRule/code-82.php
@@ -177,7 +177,7 @@ class DeductFromReturnStatements {
         return $this;
     }
 
-    public function returnResource() // error: Missing native return typehint resource|false
+    public function returnResource()
     {
         return fopen('php://memory');
     }

--- a/tests/Rule/data/EnforceNativeReturnTypehintRule/code-82.php
+++ b/tests/Rule/data/EnforceNativeReturnTypehintRule/code-82.php
@@ -285,3 +285,14 @@ class TraitUser2 {
         return new \LogicException();
     }
 }
+
+enum MyBoolean: string
+{
+    case True = 'true';
+    case False = 'false';
+
+    public static function createFromBool(bool $boolValue) // error: Missing native return typehint self
+    {
+        return $boolValue ? self::True : self::False;
+    }
+}

--- a/tests/Rule/data/EnforceNativeReturnTypehintRule/code-enum.php
+++ b/tests/Rule/data/EnforceNativeReturnTypehintRule/code-enum.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace EnforceNativeReturnTypehintRule;
+
+enum MyBoolean: string
+{
+    case True = 'true';
+    case False = 'false';
+
+    public static function createFromBool(bool $boolValue) // error: Missing native return typehint self
+    {
+        return $boolValue ? self::True : self::False;
+    }
+}


### PR DESCRIPTION
- _No type hint for resources is added, as this would prevent moving from resources to objects for existing extensions, which some have already done (e.g. GMP)._
  - https://wiki.php.net/rfc/scalar_type_hints