### PR TITLE
Improve forbidIdenticalClassComparison example

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,11 +376,8 @@ parameters:
         forbidIdenticalClassComparison:
             blacklist:
                 - DateTimeInterface
-                - Brick\Money
+                - Brick\Money\MoneyContainer
                 - Brick\Math\BigNumber
-                - Brick\Math\BigInteger
-                - Brick\Math\BigDecimal
-                - Brick\Math\BigRational
 ```
 
 ### forbidMatchDefaultArmForEnums

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ parameters:
             blacklist:
                 - Brick\Money\MoneyContainer
                 - Brick\Math\BigNumber
+                - Ramsey\Uuid\UuidInterface
 ```
 
 ### forbidMatchDefaultArmForEnums

--- a/README.md
+++ b/README.md
@@ -375,7 +375,6 @@ parameters:
     shipmonkRules:
         forbidIdenticalClassComparison:
             blacklist:
-                - DateTimeInterface
                 - Brick\Money\MoneyContainer
                 - Brick\Math\BigNumber
 ```


### PR DESCRIPTION
Adding Brick classes here was a good inspiration, thanks for that!

However:
- We can remove `DateTimeInterface` from here... the array is merged with the default configuration from `rules.neon` anyway so this way `DateTimeInterface` actually gets into `ForbidIdenticalClassComparisonRule` twice, I checked.
- `Brick\Money` doesn't exist, it's `Brick\Money\Money` and I think it's better to use the interface instead anyway to also detect `Brick\Money\RationalMoney`.
- `BigInteger`, `BigDecimal` and `BigRational` all extend `BigNumber` anyway so they're redundant.
- `ramsey/uuid` is a very commonly used library and I almost forgot to add `UuidInterface` into my config.