### PR TITLE
ForbidCheckedExceptionInYieldingMethodRule: ignore implicit throw points

### DIFF
--- a/src/Rule/ForbidCheckedExceptionInYieldingMethodRule.php
+++ b/src/Rule/ForbidCheckedExceptionInYieldingMethodRule.php
@@ -44,6 +44,10 @@ class ForbidCheckedExceptionInYieldingMethodRule implements Rule
         $errors = [];
 
         foreach ($node->getStatementResult()->getThrowPoints() as $throwPoint) {
+            if (!$throwPoint->isExplicit()) {
+                continue;
+            }
+
             foreach ($throwPoint->getType()->getObjectClassNames() as $exceptionClass) {
                 if ($this->exceptionTypeResolver->isCheckedException($exceptionClass, $throwPoint->getScope())) {
                     $errors[] = RuleErrorBuilder::message("Throwing checked exception $exceptionClass in yielding method is denied as it gets thrown upon Generator iteration")

--- a/tests/Rule/ForbidCheckedExceptionInYieldingMethodRuleTest.php
+++ b/tests/Rule/ForbidCheckedExceptionInYieldingMethodRuleTest.php
@@ -2,9 +2,11 @@
 
 namespace ShipMonk\PHPStan\Rule;
 
+use ForbidCheckedExceptionInYieldingMethodRule\CheckedException;
 use PHPStan\Rules\Exceptions\DefaultExceptionTypeResolver;
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
+use Throwable;
 
 /**
  * @extends RuleTestCase<ForbidCheckedExceptionInYieldingMethodRule>
@@ -19,7 +21,7 @@ class ForbidCheckedExceptionInYieldingMethodRuleTest extends RuleTestCase
             ->expects(self::any())
             ->method('isCheckedException')
             ->willReturnCallback(static function (string $className): bool {
-                return $className === 'ForbidCheckedExceptionInYieldingMethodRule\CheckedException';
+                return $className === CheckedException::class || $className === Throwable::class;
             });
 
         return new ForbidCheckedExceptionInYieldingMethodRule($exceptionTypeResolverMock);


### PR DESCRIPTION
I don't know what implicit throw points are, but PHPStan creates them any many places and if `Throwable` is considered a checked exception, this rule will emit lot of false positives.