### PR TITLE
AllowNamedArgumentOnlyInAttributesRule vs nested attributes

### DIFF
--- a/tests/Rule/data/AllowNamedArgumentOnlyInAttributesRule/code.php
+++ b/tests/Rule/data/AllowNamedArgumentOnlyInAttributesRule/code.php
@@ -5,6 +5,14 @@ namespace AllowNamedArgumentOnlyInAttributesRule;
 use Attribute;
 
 #[Attribute(flags: Attribute::TARGET_ALL)]
+class UniversalWrapperAttribute
+{
+    public function __construct(UniversalAttribute $attribute, NonAttributeCrate $crate)
+    {
+    }
+}
+
+#[Attribute(flags: Attribute::TARGET_ALL)]
 class UniversalAttribute
 {
     public function __construct(int $argument)
@@ -12,20 +20,27 @@ class UniversalAttribute
     }
 }
 
+class NonAttributeCrate
+{
+    public function __construct(int $value)
+    {
+    }
+}
+
 #[UniversalAttribute(argument: 1)]
 class NamedArgumentRuleExampleClass
 {
-    #[UniversalAttribute(argument: 1)]
+    #[UniversalWrapperAttribute(attribute: new UniversalAttribute(argument: 1), crate: new NonAttributeCrate(value: 2))]
     public string $foo;
 
-    #[UniversalAttribute(argument: 1)]
+    #[UniversalWrapperAttribute(attribute: new UniversalAttribute(argument: 1), crate: new NonAttributeCrate(value: 2))]
     private const MY_CONST = 'const';
 
-    #[UniversalAttribute(argument: 1)]
+    #[UniversalWrapperAttribute(attribute: new UniversalAttribute(argument: 1), crate: new NonAttributeCrate(value: 2))]
     private string $myProperty;
 
-    #[UniversalAttribute(argument: 1)]
-    public function myMethod(#[UniversalAttribute(argument: 5)] int $arg): void
+    #[UniversalWrapperAttribute(attribute: new UniversalAttribute(argument: 1), crate: new NonAttributeCrate(value: 2))]
+    public function myMethod(#[UniversalWrapperAttribute(attribute: new UniversalAttribute(argument: 1), crate: new NonAttributeCrate(value: 2))] int $arg): void
     {
         $this->myMethod(arg: 1); // error: Named arguments are allowed only within native attributes
         var_dump(value: 1); // error: Named arguments are allowed only within native attributes
@@ -34,7 +49,7 @@ class NamedArgumentRuleExampleClass
 
     public static function myStaticMethod(int $arg): void
     {
-
+        $foo = new UniversalAttribute(argument: 1); // error: Named arguments are allowed only within native attributes
     }
 
 }


### PR DESCRIPTION
Currently the rule flags named arguments of nested attributes and I think it should be relaxed a bit. The question is how much?

Should the named arguments be allowed anywhere within the attribute block, i.e. even in combination with non-attribute class? I lean towards yes-answer.