### PR TITLE
RuleTestCase: error tagging to allow reusal of php templates

### DIFF
--- a/tests/RuleTestCase.php
+++ b/tests/RuleTestCase.php
@@ -5,9 +5,12 @@ namespace ShipMonk\PHPStan;
 use LogicException;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase as OriginalRuleTestCase;
+use function array_filter;
+use function array_values;
 use function explode;
 use function file_get_contents;
 use function preg_match_all;
+use function preg_quote;
 use function trim;
 
 /**
@@ -17,16 +20,20 @@ use function trim;
 abstract class RuleTestCase extends OriginalRuleTestCase
 {
 
-    protected function analyseFile(string $file): void
+    /**
+     * @param list<string> $errorTags
+     */
+    protected function analyseFile(string $file, array $errorTags = []): void
     {
         $file = $this->getFileHelper()->normalizePath($file);
-        $this->analyse([$file], $this->parseExpectedErrors($file));
+        $this->analyse([$file], $this->parseExpectedErrors($file, $errorTags));
     }
 
     /**
+     * @param list<string> $errorTags
      * @return list<array{0: string, 1: int}>
      */
-    private function parseExpectedErrors(string $file): array
+    private function parseExpectedErrors(string $file, array $errorTags): array
     {
         $fileData = file_get_contents($file);
 
@@ -39,26 +46,46 @@ abstract class RuleTestCase extends OriginalRuleTestCase
         $expectedErrors = [];
 
         foreach ($fileDataLines as $line => $row) {
-            $matches = [];
-            $matched = preg_match_all('#// error:(.+)#', $row, $matches);
+            $expectedErrors[] = $this->getExpectedErrorForLine($line, $row, null);
 
-            if ($matched === false) {
-                throw new LogicException('Error while matching errors');
-            }
-
-            if ($matched === 0) {
-                continue;
-            }
-
-            foreach ($matches[1] as $error) {
-                $expectedErrors[] = [
-                    trim($error),
-                    $line + 1,
-                ];
+            foreach ($errorTags as $errorTag) {
+                $expectedErrors[] = $this->getExpectedErrorForLine($line, $row, $errorTag);
             }
         }
 
-        return $expectedErrors;
+        return array_values(array_filter($expectedErrors));
+    }
+
+    /**
+     * @return array{0: string, 1: int}|null
+     */
+    private function getExpectedErrorForLine(int $line, string $row, ?string $errorTag): ?array
+    {
+        $matches = [];
+
+        if ($errorTag === null) {
+            $matched = preg_match_all('#// error:(.+)#', $row, $matches);
+        } else {
+            $errorTagRegex = preg_quote($errorTag, '#');
+            $matched = preg_match_all('#// error \(' . $errorTagRegex . '\):(.+)#', $row, $matches);
+        }
+
+        if ($matched === false) {
+            throw new LogicException('Error while matching errors');
+        }
+
+        if ($matched === 0) {
+            return null;
+        }
+
+        foreach ($matches[1] as $error) {
+            return [
+                trim($error),
+                $line + 1,
+            ];
+        }
+
+        return null;
     }
 
 }


### PR DESCRIPTION
The idea is that you have single code.php and you have multiple testcases slightly adjusting some params resulting in different errors reported. So you can do
```php
generic error always reported // error: Missing native return typehint array
reported only when called with $this->analyseFile(..., ["php 8.2"]) // error (php 8.2): Missing native return typehint null
```

But it does not help when error on certain line change with some setup.