### PR TITLE
Run tests even with PHP 8.3

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '7.4', '8.0', '8.1', '8.2' ]
+                php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
         steps:
             -


### PR DESCRIPTION
- likely doable once we tag https://github.com/shipmonk-rnd/name-collision-detector as the upcoming version does not need betterreflection