### PR TITLE
Immediately Called Callables config & class inheritance

### DIFF
--- a/tests/Extension/data/ImmediatelyCalledCallableThrowTypeExtension/code.php
+++ b/tests/Extension/data/ImmediatelyCalledCallableThrowTypeExtension/code.php
@@ -5,11 +5,29 @@ namespace ImmediatelyCalledCallableThrowTypeExtension;
 use PHPStan\TrinaryLogic;
 use function PHPStan\Testing\assertVariableCertainty;
 
-class Immediate {
+interface ImmediateInterface {
+
+    public function inheritedMethod(callable $first, callable $second): int;
+
+}
+
+class BaseImmediate implements ImmediateInterface {
+
+    public function inheritedMethod(callable $first, callable $second): int {
+        $first();
+        $second();
+        return 1;
+    }
+
+}
+
+class Immediate extends BaseImmediate {
+
     public static function method(callable $callable): int {
         $callable();
         return 1;
     }
+
 }
 
 class MethodCallExtensionTest
@@ -86,6 +104,27 @@ class MethodCallExtensionTest
             $result = Immediate::method($this->noThrow(...));
         } finally {
             assertVariableCertainty(TrinaryLogic::createYes(), $result);
+        }
+    }
+
+    public function testInheritedMethod(): void
+    {
+        try {
+            $result1 = (new Immediate())->inheritedMethod($this->noThrow(...), $this->noThrow(...));
+        } finally {
+            assertVariableCertainty(TrinaryLogic::createYes(), $result1);
+        }
+
+        try {
+            $result2 = (new Immediate())->inheritedMethod($this->throw(...), $this->noThrow(...));
+        } finally {
+            assertVariableCertainty(TrinaryLogic::createMaybe(), $result2);
+        }
+
+        try {
+            $result3 = (new Immediate())->inheritedMethod($this->noThrow(...), $this->throw(...));
+        } finally {
+            assertVariableCertainty(TrinaryLogic::createMaybe(), $result3);
         }
     }
 

--- a/tests/Extension/data/ImmediatelyCalledCallableThrowTypeExtension/extension.neon
+++ b/tests/Extension/data/ImmediatelyCalledCallableThrowTypeExtension/extension.neon
@@ -8,5 +8,7 @@ services:
         arguments:
             immediatelyCalledCallables:
                 array_map: 0
+                ImmediatelyCalledCallableThrowTypeExtension\ImmediateInterface::inheritedMethod: 0
+                ImmediatelyCalledCallableThrowTypeExtension\BaseImmediate::inheritedMethod: 1
                 ImmediatelyCalledCallableThrowTypeExtension\Immediate::method: [0, 1]
 

--- a/tests/Rule/data/ForbidCheckedExceptionInCallableRule/code.php
+++ b/tests/Rule/data/ForbidCheckedExceptionInCallableRule/code.php
@@ -9,7 +9,35 @@ class CheckedException extends \Exception {}
  */
 function throwing_function() {}
 
-class FirstClassCallableTest {
+interface CallableTest {
+
+    public function allowThrowInInterface(callable $callable): void;
+
+}
+
+class BaseCallableTest implements CallableTest {
+
+    public function allowThrowInInterface(callable $callable): void
+    {
+        try {
+            $callable();
+        } catch (\Exception $e) {
+
+        }
+    }
+
+    public function allowThrowInBaseClass(callable $callable): void
+    {
+        try {
+            $callable();
+        } catch (\Exception $e) {
+
+        }
+    }
+
+}
+
+class FirstClassCallableTest extends BaseCallableTest {
 
     public function testDeclarations(): void
     {
@@ -34,7 +62,7 @@ class FirstClassCallableTest {
 
     public function testPassedCallbacks(): void
     {
-        $this->immediateThrow(42, $this->throws(...));
+        $this->immediateThrow(null, $this->throws(...));
 
         array_map($this->throws(...), []);
 
@@ -48,6 +76,10 @@ class FirstClassCallableTest {
             $this->throws(...), // error: Throwing checked exception ForbidCheckedExceptionInCallableRule\CheckedException in first-class-callable!
             function () {},
         );
+
+        $this->allowThrowInBaseClass(throwing_function(...));
+
+        $this->allowThrowInInterface(throwing_function(...));
 
         $this->denied($this->throws(...)); // error: Throwing checked exception ForbidCheckedExceptionInCallableRule\CheckedException in first-class-callable!
     }
@@ -85,7 +117,7 @@ class FirstClassCallableTest {
 
 }
 
-class ClosureTest {
+class ClosureTest extends BaseCallableTest {
 
     public function testDeclarations(): void
     {
@@ -142,6 +174,14 @@ class ClosureTest {
                 throw new CheckedException(); // error: Throwing checked exception ForbidCheckedExceptionInCallableRule\CheckedException in closure!
             },
         );
+
+        $this->allowThrowInBaseClass(function () {
+            $this->throws();
+        });
+
+        $this->allowThrowInInterface(function () {
+            $this->throws();
+        });
 
         $this->denied(function () {
             throw new CheckedException(); // error: Throwing checked exception ForbidCheckedExceptionInCallableRule\CheckedException in closure!

--- a/tests/Rule/data/ForbidCheckedExceptionInCallableRule/visitor.neon
+++ b/tests/Rule/data/ForbidCheckedExceptionInCallableRule/visitor.neon
@@ -7,6 +7,8 @@ services:
                 'ForbidCheckedExceptionInCallableRule\ClosureTest::immediateThrow': 0
                 'ForbidCheckedExceptionInCallableRule\FirstClassCallableTest::immediateThrow': 1
             allowedCheckedExceptionCallables:
+                'ForbidCheckedExceptionInCallableRule\CallableTest::allowThrowInInterface': [0]
+                'ForbidCheckedExceptionInCallableRule\BaseCallableTest::allowThrowInBaseClass': [0]
                 'ForbidCheckedExceptionInCallableRule\ClosureTest::allowThrow': [0]
                 'ForbidCheckedExceptionInCallableRule\FirstClassCallableTest::allowThrow': [1]
         tags:


### PR DESCRIPTION
**Goal:**
Ensure immediately called callable argument is recognized on any subtype of the class/interface specified in config.

**Example:**
```
immediatelyCalledCallables:
    'Doctrine\ORM\EntityManagerInterface::transactional': 0 # immediately called callable argument is recognized on any implementation of EntityManagerInterface
```

- Added test for existing support in`ForbidCheckedExceptionInCallableRule`
- Added missing support to `ImmediatelyCalledCallableThrowTypeExtension`