### PR TITLE
ImmediatelyCalledCallableThrowTypeExtension: ignore implicit throw points

### DIFF
--- a/src/Extension/ImmediatelyCalledCallableThrowTypeExtension.php
+++ b/src/Extension/ImmediatelyCalledCallableThrowTypeExtension.php
@@ -147,7 +147,9 @@ class ImmediatelyCalledCallableThrowTypeExtension implements DynamicFunctionThro
                 );
 
                 foreach ($result->getThrowPoints() as $throwPoint) {
-                    $throwTypes[] = $throwPoint->getType();
+                    if ($throwPoint->isExplicit()) {
+                        $throwTypes[] = $throwPoint->getType();
+                    }
                 }
             }
 
@@ -161,7 +163,9 @@ class ImmediatelyCalledCallableThrowTypeExtension implements DynamicFunctionThro
                 );
 
                 foreach ($result->getThrowPoints() as $throwPoint) {
-                    $throwTypes[] = $throwPoint->getType();
+                    if ($throwPoint->isExplicit()) {
+                        $throwTypes[] = $throwPoint->getType();
+                    }
                 }
             }
 


### PR DESCRIPTION
When `Traversable` type is iterated inside immediately called callable, PHPStan [will add](https://github.com/phpstan/phpstan-src/commit/d32942a3158a26f08252638dc660467292bbf881) implicit throw point.

The `Throwable` type that comes from this implicit throw point will override all explicit throw points (because [union](https://github.com/shipmonk-rnd/phpstan-rules/blob/a47f65fbfa01b4ffe0ab953a219fd87f5304df9b/src/Extension/ImmediatelyCalledCallableThrowTypeExtension.php#L205) of `Throwable` with any exception will resolve to `Throwable`).

I did not figure out how to write test for this.