### PR TITLE
Make nikic/php-parser a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "nikic/php-parser": "^4.14.0",
         "phpstan/phpstan": "^1.10.51"
     },
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "^10.3.0",
         "ergebnis/composer-normalize": "^2.28",
         "nette/neon": "^3.3.1",
+        "nikic/php-parser": "^4.14.0",
         "phpstan/phpstan-phpunit": "^1.1.1",
         "phpstan/phpstan-strict-rules": "^1.2.3",
         "phpunit/phpunit": "^9.5.20",


### PR DESCRIPTION
See #220 

`nikic/php-parser:^4.14.0` dependency blocks some update (notably phpUnit 11). 

As in as in [phpstan-strict-rules](https://github.com/phpstan/phpstan-strict-rules) this may be a dev dependency.

This MR is simply the result of:

```
composer require --dev --no-update nikic/php-parser:^4.14.0
```
