### PR TITLE
composer-dependency-analyser: prepend PHPStan's PharAutoloader to avoid false reports, drop nikic/php-parser

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,9 +1,10 @@
 <?php declare(strict_types = 1);
 
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
-use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
-$config = new Configuration();
+$pharFile = __DIR__ . '/vendor/phpstan/phpstan/phpstan.phar';
+Phar::loadPhar($pharFile, 'phpstan.phar');
 
-return $config
-    ->ignoreErrorsOnPackage('phpstan/phpdoc-parser', [ErrorType::SHADOW_DEPENDENCY]); // it gets autoloaded from within the PHPStan.phar when running PHPStan
+require_once('phar://phpstan.phar/preload.php'); // prepends PHPStan's PharAutolaoder to composer's autoloader
+
+return new Configuration();

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "nikic/php-parser": "^4.14.0",
         "phpstan/phpstan": "^1.10.51"
     },
     "require-dev": {
@@ -21,7 +20,7 @@
         "phpstan/phpstan-phpunit": "^1.1.1",
         "phpstan/phpstan-strict-rules": "^1.2.3",
         "phpunit/phpunit": "^9.5.20",
-        "shipmonk/composer-dependency-analyser": "dev-support-more-loaders",
+        "shipmonk/composer-dependency-analyser": "^1.3.0",
         "shipmonk/name-collision-detector": "^2.0.0",
         "slevomat/coding-standard": "^8.0.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpstan/phpstan-phpunit": "^1.1.1",
         "phpstan/phpstan-strict-rules": "^1.2.3",
         "phpunit/phpunit": "^9.5.20",
-        "shipmonk/composer-dependency-analyser": "^1.2.0",
+        "shipmonk/composer-dependency-analyser": "dev-support-more-loaders",
         "shipmonk/name-collision-detector": "^2.0.0",
         "slevomat/coding-standard": "^8.0.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,64 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d8206d632544cd49a8691adba5daea3",
+    "content-hash": "5670f1b56cdde7f4148e5623e7406692",
     "packages": [
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.18.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
-            },
-            "time": "2023-12-10T21:03:43+00:00"
-        },
         {
             "name": "phpstan/phpstan",
             "version": "1.10.59",
@@ -1139,6 +1083,64 @@
                 "source": "https://github.com/nette/utils/tree/v4.0.4"
             },
             "time": "2024-01-17T16:50:36+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/2218c2252c874a4624ab2f613d86ac32d227bc69",
+                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.1"
+            },
+            "time": "2024-02-21T19:24:10+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2787,16 +2789,16 @@
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
-            "version": "dev-support-more-loaders",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/composer-dependency-analyser.git",
-                "reference": "0ae84077b0145a8c0a0fa1ac80cedef568801157"
+                "reference": "e7db6877e70c22c146e5f4af1de0d2703102ad2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/composer-dependency-analyser/zipball/0ae84077b0145a8c0a0fa1ac80cedef568801157",
-                "reference": "0ae84077b0145a8c0a0fa1ac80cedef568801157",
+                "url": "https://api.github.com/repos/shipmonk-rnd/composer-dependency-analyser/zipball/e7db6877e70c22c146e5f4af1de0d2703102ad2b",
+                "reference": "e7db6877e70c22c146e5f4af1de0d2703102ad2b",
                 "shasum": ""
             },
             "require": {
@@ -2843,9 +2845,9 @@
             ],
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/composer-dependency-analyser/issues",
-                "source": "https://github.com/shipmonk-rnd/composer-dependency-analyser/tree/support-more-loaders"
+                "source": "https://github.com/shipmonk-rnd/composer-dependency-analyser/tree/1.3.0"
             },
-            "time": "2024-03-04T11:55:20+00:00"
+            "time": "2024-03-04T17:51:44+00:00"
         },
         {
             "name": "shipmonk/name-collision-detector",
@@ -3092,9 +3094,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "shipmonk/composer-dependency-analyser": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc41a95b3f6b8bd065c5684a3da0ea87",
+    "content-hash": "9d8206d632544cd49a8691adba5daea3",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -2787,16 +2787,16 @@
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
-            "version": "1.2.1",
+            "version": "dev-support-more-loaders",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/composer-dependency-analyser.git",
-                "reference": "d44a0ec7d3b66fd73d5c32981c81569c9b85bddc"
+                "reference": "0ae84077b0145a8c0a0fa1ac80cedef568801157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/composer-dependency-analyser/zipball/d44a0ec7d3b66fd73d5c32981c81569c9b85bddc",
-                "reference": "d44a0ec7d3b66fd73d5c32981c81569c9b85bddc",
+                "url": "https://api.github.com/repos/shipmonk-rnd/composer-dependency-analyser/zipball/0ae84077b0145a8c0a0fa1ac80cedef568801157",
+                "reference": "0ae84077b0145a8c0a0fa1ac80cedef568801157",
                 "shasum": ""
             },
             "require": {
@@ -2843,9 +2843,9 @@
             ],
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/composer-dependency-analyser/issues",
-                "source": "https://github.com/shipmonk-rnd/composer-dependency-analyser/tree/1.2.1"
+                "source": "https://github.com/shipmonk-rnd/composer-dependency-analyser/tree/support-more-loaders"
             },
-            "time": "2024-02-16T10:44:07+00:00"
+            "time": "2024-03-04T11:55:20+00:00"
         },
         {
             "name": "shipmonk/name-collision-detector",
@@ -3092,7 +3092,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "shipmonk/composer-dependency-analyser": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
This should prevent errors like #220, now it (properly) [detected](https://github.com/shipmonk-rnd/phpstan-rules/actions/runs/8140512120/job/22245841427#step:5:350) the `nikic/php-parser` as unused:

![image](https://github.com/shipmonk-rnd/phpstan-rules/assets/1993453/e57927f6-bef0-41c8-a29b-1fbb59f55a7c)

Package `nikic/php-parser` is bundled inside PHPStan's phar and is loaded from there, so having it in `require` is useless.
