### PR TITLE
ImmediatelyCalledCallableThrowTypeExtension: use implicitThrows: false in test

### DIFF
--- a/tests/Extension/data/ImmediatelyCalledCallableThrowTypeExtension/code.php
+++ b/tests/Extension/data/ImmediatelyCalledCallableThrowTypeExtension/code.php
@@ -173,7 +173,7 @@ class FunctionCallExtensionTest
         try {
             $result = array_map('ucfirst', []);
         } finally {
-            assertVariableCertainty(TrinaryLogic::createMaybe(), $result);  // should be Yes https://github.com/phpstan/phpstan-src/pull/3016
+            assertVariableCertainty(TrinaryLogic::createYes(), $result);
         }
     }
 
@@ -240,7 +240,7 @@ class FunctionCallExtensionTest
         try {
             $result = array_map($this->noThrow(...), []);
         } finally {
-            assertVariableCertainty(TrinaryLogic::createMaybe(), $result); // should be Yes https://github.com/phpstan/phpstan-src/pull/3016
+            assertVariableCertainty(TrinaryLogic::createYes(), $result);
         }
     }
 

--- a/tests/Extension/data/ImmediatelyCalledCallableThrowTypeExtension/extension.neon
+++ b/tests/Extension/data/ImmediatelyCalledCallableThrowTypeExtension/extension.neon
@@ -12,3 +12,6 @@ services:
                 ImmediatelyCalledCallableThrowTypeExtension\BaseImmediate::inheritedMethod: 1
                 ImmediatelyCalledCallableThrowTypeExtension\Immediate::method: [0, 1]
 
+parameters:
+    exceptions:
+        implicitThrows: false


### PR DESCRIPTION
Ref: https://github.com/phpstan/phpstan-src/pull/3016#issuecomment-2109863645