### PR TITLE
Remove deprecated ParametersAcceptorSelector::selectFromArgs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "phpstan/phpstan": "^1.11.0"
+        "phpstan/phpstan": "^1.12.5"
     },
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "^10.6.0",

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "check:ec": "ec src tests",
         "check:ignores": "php bin/verify-inline-ignore.php",
         "check:tests": "phpunit -vvv tests",
-        "check:types": "phpstan analyse -vvv --ansi",
+        "check:types": "phpstan analyse -vv --ansi",
         "fix:cs": "phpcbf"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c96a6052cb31cb9438f71055604c9630",
+    "content-hash": "c9c06c7268b4ea221c6db80af3e0e396",
     "packages": [
         {
             "name": "phpstan/phpstan",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.0",
+            "version": "1.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1"
+                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/384af967d35b2162f69526c7276acadce534d0e1",
-                "reference": "384af967d35b2162f69526c7276acadce534d0e1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
+                "reference": "7e6c6cb7cecb0a6254009a1a8a7d54ec99812b17",
                 "shasum": ""
             },
             "require": {
@@ -62,7 +62,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-27T09:18:05+00:00"
+            "time": "2024-09-26T12:45:22+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Rule/ForbidReturnValueInYieldingMethodRule.php
+++ b/src/Rule/ForbidReturnValueInYieldingMethodRule.php
@@ -8,7 +8,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClosureReturnStatementsNode;
 use PHPStan\Node\MethodReturnStatementsNode;
 use PHPStan\Node\ReturnStatementsNode;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -90,7 +89,7 @@ class ForbidReturnValueInYieldingMethodRule implements Rule
         }
 
         if ($methodReflection !== null) {
-            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+            return $methodReflection->getReturnType();
         }
 
         return new MixedType();

--- a/src/Rule/ForbidUselessNullableReturnRule.php
+++ b/src/Rule/ForbidUselessNullableReturnRule.php
@@ -6,7 +6,6 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClosureReturnStatementsNode;
 use PHPStan\Node\ReturnStatementsNode;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -39,7 +38,7 @@ class ForbidUselessNullableReturnRule implements Rule
         if ($node instanceof ClosureReturnStatementsNode) {
             $declaredType = $scope->getFunctionType($node->getClosureExpr()->getReturnType(), false, false);
         } elseif ($methodReflection !== null) {
-            $declaredType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+            $declaredType = $methodReflection->getReturnType();
         } else {
             return [];
         }

--- a/src/Rule/RequirePreviousExceptionPassRule.php
+++ b/src/Rule/RequirePreviousExceptionPassRule.php
@@ -171,7 +171,11 @@ class RequirePreviousExceptionPassRule implements Rule
 
         // FuncCall not yet supported
         if ($methodReflection !== null) {
-            return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getParameters();
+            return ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                $node->getArgs(),
+                $methodReflection->getVariants(),
+            )->getParameters();
         }
 
         return [];


### PR DESCRIPTION
- bumps lowest phpstan/phpstan from 1.11.0 to 1.12.5 to be able to use new api to resolve the deprecation with preferred way
- eliminates new deprecation https://github.com/phpstan/phpstan-src/commit/23c53a2210b715f672ad3087dd476faf34bdec6e