### PR TITLE
forbidEnumInFunctionArguments: skip those detected by PHPStan itself

### DIFF
--- a/tests/Rule/data/ForbidEnumInFunctionArgumentsRule/code.php
+++ b/tests/Rule/data/ForbidEnumInFunctionArgumentsRule/code.php
@@ -22,23 +22,23 @@ class Test
         $enums2 = [SomeEnum::Bar];
         $enums3 = [SomeEnum::Baz];
 
-        array_intersect($enums1, $enums2, $enums3); // error: Arguments 1, 2, 3 in array_intersect() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
-        array_intersect_assoc($enums1, $enums2, $enums3); // error: Arguments 1, 2, 3 in array_intersect_assoc() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
-        array_diff($enums1, $enums2, $enums3); // error: Arguments 1, 2, 3 in array_diff() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
-        array_diff_assoc($enums1, $enums2, $enums3); // error: Arguments 1, 2, 3 in array_diff_assoc() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
-        array_unique($enums1); // error: Argument 1 in array_unique() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
-        array_combine($enums2, $enums3); // error: Argument 1 in array_combine() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
+        array_intersect($enums1, $enums2, $enums3); // reported by native PHPStan
+        array_intersect_assoc($enums1, $enums2, $enums3); // reported by native PHPStan
+        array_diff($enums1, $enums2, $enums3); // reported by native PHPStan
+        array_diff_assoc($enums1, $enums2, $enums3); // reported by native PHPStan
+        array_unique($enums1); // reported by native PHPStan
+        array_combine($enums2, $enums3); // reported by native PHPStan
         sort($enums1); // error: Argument 1 in sort() cannot contain enum as the function causes unexpected results
         asort($enums1); // error: Argument 1 in asort() cannot contain enum as the function causes unexpected results
         arsort($enums1); // error: Argument 1 in arsort() cannot contain enum as the function causes unexpected results
-        natsort($enums1); // error: Argument 1 in natsort() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
-        natcasesort($enums1); // error: Argument 1 in natcasesort() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
-        array_count_values($enums1); // error: Argument 1 in array_count_values() cannot contain enum as the function will skip any enums and produce warning
-        array_fill_keys($enums1, 1); // error: Argument 1 in array_fill_keys() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
-        array_flip($enums1); // error: Argument 1 in array_flip() cannot contain enum as the function will skip any enums and produce warning
+        natsort($enums1); // reported by native PHPStan
+        natcasesort($enums1); // reported by native PHPStan
+        array_count_values($enums1); // reported by native PHPStan
+        array_fill_keys($enums1, 1); // reported by native PHPStan
+        array_flip($enums1); // reported by native PHPStan
         array_product($enums1); // error: Argument 1 in array_product() cannot contain enum as the function causes unexpected results
         array_sum($enums1); // error: Argument 1 in array_sum() cannot contain enum as the function causes unexpected results
-        implode('', $enums1); // error: Argument 2 in implode() cannot contain enum as the function causes implicit __toString conversion which is not supported for enums
+        implode('', $enums1); // reported by native PHPStan
         in_array(SomeEnum::Bar, $enums1);
     }
 


### PR DESCRIPTION
Over the years, PHPStan finally got support to most of the cases, so we can drop most of them.