### PR TITLE
ForbidVariableTypeOverwriting: relax allowed narrowing and generalization

### DIFF
--- a/src/Rule/ForbidVariableTypeOverwritingRule.php
+++ b/src/Rule/ForbidVariableTypeOverwritingRule.php
@@ -60,10 +60,10 @@ class ForbidVariableTypeOverwritingRule implements Rule
             return [];
         }
 
-        if (
-            !$previousVariableType->isSuperTypeOf($newVariableType)->yes() // allow narrowing
-            && !$newVariableType->isSuperTypeOf($previousVariableType)->yes() // allow generalization
-        ) {
+        $narrowing = $previousVariableType->accepts($newVariableType, true)->yes();
+        $generalization = $newVariableType->accepts($previousVariableType, true)->yes();
+
+        if (!$narrowing && !$generalization) {
             $error = RuleErrorBuilder::message("Overwriting variable \$$variableName while changing its type from {$previousVariableType->describe(VerbosityLevel::precise())} to {$newVariableType->describe(VerbosityLevel::precise())}")
                 ->identifier('shipmonk.variableTypeOverwritten')
                 ->build();

--- a/tests/Rule/data/ForbidVariableTypeOverwritingRule/code.php
+++ b/tests/Rule/data/ForbidVariableTypeOverwritingRule/code.php
@@ -151,3 +151,11 @@ function testEnumCaseChange() {
 function testIntToInt(int $positive, int $negative) {
     $positive = $negative;
 }
+
+function testFloatToInt(float $float, int $int) {
+    $float = $int;
+}
+
+function testFIntToFloat(int $int, float $float) {
+    $int = $float;
+}


### PR DESCRIPTION
Since https://github.com/phpstan/phpstan-src/pull/3853, following assignment:

```php
interface SomeInterface {}
class SomeClass {}

function test(SomeInterface & SomeClass $classWithInterface) {
    $classWithInterface = new SomeClass();
}

```

no longer passes the old condition as those are false:

```php
$previousVariableType->isSuperTypeOf($newVariableType)->yes(); // false
$newVariableType->isSuperTypeOf($previousVariableType)->yes(); // false
```

