### PR TITLE
EnforceReadonlyPublicProperty: exclude hooked properties

### DIFF
--- a/src/Rule/EnforceReadonlyPublicPropertyRule.php
+++ b/src/Rule/EnforceReadonlyPublicPropertyRule.php
@@ -38,15 +38,11 @@ class EnforceReadonlyPublicPropertyRule implements Rule
             return [];
         }
 
-        if (!$node->isPublic() || $node->isReadOnly()) {
+        if (!$node->isPublic() || $node->isReadOnly() || $node->hasHooks()) {
             return [];
         }
 
         $classReflection = $node->getClassReflection();
-
-        if ($classReflection->isInterface()) {
-            return []; // unable to mark hooked properties on interfaces as readonly
-        }
 
         if (($classReflection->getNativeReflection()->getModifiers() & 65_536) !== 0) { // readonly class, since PHP 8.2
             return [];

--- a/src/Rule/EnforceReadonlyPublicPropertyRule.php
+++ b/src/Rule/EnforceReadonlyPublicPropertyRule.php
@@ -42,10 +42,10 @@ class EnforceReadonlyPublicPropertyRule implements Rule
             return [];
         }
 
-        $classReflection = $scope->getClassReflection();
+        $classReflection = $node->getClassReflection();
 
-        if ($classReflection === null) {
-            return [];
+        if ($classReflection->isInterface()) {
+            return []; // unable to mark hooked properties on interfaces as readonly
         }
 
         if (($classReflection->getNativeReflection()->getModifiers() & 65_536) !== 0) { // readonly class, since PHP 8.2

--- a/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
+++ b/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
@@ -5,6 +5,7 @@ namespace ShipMonk\PHPStan\Rule;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<EnforceReadonlyPublicPropertyRule>
@@ -22,6 +23,10 @@ class EnforceReadonlyPublicPropertyRuleTest extends RuleTestCase
 
     public function testPhp84(): void
     {
+        if (PHP_VERSION_ID < 8_00_00) {
+            self::markTestSkipped('PHP7 parser fails with property hooks');
+        }
+
         $this->phpVersion = $this->createPhpVersion(80_400);
         $this->analyseFile(__DIR__ . '/data/EnforceReadonlyPublicPropertyRule/code-84.php');
     }

--- a/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
+++ b/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
@@ -20,6 +20,12 @@ class EnforceReadonlyPublicPropertyRuleTest extends RuleTestCase
         return new EnforceReadonlyPublicPropertyRule($this->phpVersion);
     }
 
+    public function testPhp84(): void
+    {
+        $this->phpVersion = $this->createPhpVersion(80_400);
+        $this->analyseFile(__DIR__ . '/data/EnforceReadonlyPublicPropertyRule/code-84.php');
+    }
+
     public function testPhp81(): void
     {
         $this->phpVersion = $this->createPhpVersion(80_100);

--- a/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-84.php
+++ b/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-84.php
@@ -50,3 +50,10 @@ interface MyInterface {
     public string $key { get; }
 }
 
+class ImplementingClass implements MyInterface {
+    public string $key; // error: Public property `key` not marked as readonly.
+}
+
+class ImplementingClass2 implements MyInterface {
+    public readonly string $key;
+}

--- a/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-84.php
+++ b/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-84.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace EnforceReadonlyPublicPropertyRule84;
+
+trait MyTrait {
+
+    public ?string $public; // error: Public property `public` not marked as readonly.
+
+    public ?string $hooked { get => $this->hooked; }
+
+    public readonly string $publicReadonly;
+
+    protected string $protected;
+
+    private string $private;
+
+}
+
+class MyClass {
+
+    use MyTrait;
+
+    public ?int $foo; // error: Public property `foo` not marked as readonly.
+
+    public ?string $classHooked { set => strtolower($value); }
+
+    public readonly int $bar;
+
+    protected int $baz;
+
+    private int $bag;
+
+}
+
+readonly class MyReadonlyClass {
+
+    public ?int $foo;
+
+    public readonly int $bar;
+
+    public ?string $hooked { get => $this->hooked; }
+
+    protected int $baz;
+
+    private int $bag;
+
+}
+
+interface MyInterface {
+    public string $key { get; }
+}
+


### PR DESCRIPTION
- Closes #300
- https://wiki.php.net/rfc/property-hooks#interaction_with_readonly

> For that reason, a readonly property with a get or set hook is disallowed and will throw a compile error.