### PR TITLE
EnforceReadonlyPublicProperty: add support for Nette Inject

### DIFF
--- a/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
+++ b/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
@@ -43,6 +43,12 @@ class EnforceReadonlyPublicPropertyRuleTest extends RuleTestCase
         $this->analyseFile(__DIR__ . '/data/EnforceReadonlyPublicPropertyRule/code-80.php');
     }
 
+    public function testNetteInject(): void
+    {
+        $this->phpVersion = $this->createPhpVersion(80_100);
+        $this->analyseFile(__DIR__ . '/data/EnforceReadonlyPublicPropertyRule/code-nette-inject.php');
+    }
+
     private function createPhpVersion(int $version): PhpVersion
     {
         return new PhpVersion($version); // @phpstan-ignore phpstanApi.constructor

--- a/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-nette-inject.php
+++ b/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-nette-inject.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EnforceReadonlyPublicPropertyRule84;
+
+use Nette\DI\Attributes\Inject;
+
+class MyPresenterClass {
+
+    #[Inject]
+    public int $foo;
+
+    /** @inject */
+    public int $foo2;
+
+    public int $foo3; // error: Public property `foo3` not marked as readonly.
+
+    /**
+     * @int
+     * @inject with comment
+     * @deprecated
+     */
+    public int $foo4;
+}


### PR DESCRIPTION
```
Nette\InvalidStateException

Property App\ApiModule\ErrorPresenter::$responseFactory for injection must not be readonly.
```