### PR TITLE
ForbidUnusedMatchResultRule: count match implicitly returned by arrow function as used

### DIFF
--- a/src/Visitor/UnusedMatchVisitor.php
+++ b/src/Visitor/UnusedMatchVisitor.php
@@ -5,6 +5,7 @@ namespace ShipMonk\PHPStan\Visitor;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr\ArrowFunction;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\AssignOp;
 use PhpParser\Node\Expr\BinaryOp\Coalesce;
@@ -86,7 +87,8 @@ class UnusedMatchVisitor extends NodeVisitorAbstract
             || $parent instanceof Ternary
             || $parent instanceof MatchArm
             || $parent instanceof Yield_
-            || $parent instanceof YieldFrom;
+            || $parent instanceof YieldFrom
+            || $parent instanceof ArrowFunction;
     }
 
 }

--- a/tests/Rule/data/ForbidUnusedMatchResultRule/code.php
+++ b/tests/Rule/data/ForbidUnusedMatchResultRule/code.php
@@ -70,6 +70,18 @@ class Clazz {
             1 => 'y',
         } : null;
 
+        function ($int) {
+            return match ($int) {
+                0 => 'x',
+                1 => 'y',
+            };
+        };
+
+        fn () => match ($int) {
+            0 => 'x',
+            1 => 'y',
+        };
+
         return match ($bool) {
             false => 1,
             true => 2,


### PR DESCRIPTION
Implicitly returning result of match using an arrow function was not counted as used.