### PR TITLE
ForbidUselessNullableReturnRule: ignore for overridable errors

### DIFF
--- a/src/Rule/ForbidUselessNullableReturnRule.php
+++ b/src/Rule/ForbidUselessNullableReturnRule.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClosureReturnStatementsNode;
 use PHPStan\Node\ReturnStatementsNode;
+use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -37,6 +38,10 @@ class ForbidUselessNullableReturnRule implements Rule
     {
         $verbosity = VerbosityLevel::precise();
         $methodReflection = $scope->getFunction();
+
+        if ($methodReflection instanceof MethodReflection && $this->isOverridable($methodReflection)) {
+            return [];
+        }
 
         if ($node instanceof ClosureReturnStatementsNode) {
             $declaredType = $scope->getFunctionType($node->getClosureExpr()->getReturnType(), false, false);
@@ -78,6 +83,11 @@ class ForbidUselessNullableReturnRule implements Rule
         }
 
         return [];
+    }
+
+    private function isOverridable(MethodReflection $methodReflection): bool
+    {
+        return !$methodReflection->isFinal()->yes() && !$methodReflection->isPrivate() && !$methodReflection->isStatic() && !$methodReflection->getDeclaringClass()->isFinal();
     }
 
 }

--- a/tests/Rule/data/ForbidUselessNullableReturnRule/code.php
+++ b/tests/Rule/data/ForbidUselessNullableReturnRule/code.php
@@ -2,7 +2,7 @@
 
 namespace ForbidUselessNullableReturnRule;
 
-class ExampleClass {
+final class ExampleClass {
 
     private ?int $foo;
 
@@ -87,3 +87,30 @@ function nullableFunction(int $int): ?int // error: Declared return type int|nul
 $globalFn = static function (int $int): ?int { // error: Declared return type int|null contains null, but it is never returned. Returned types: int.
     return $int;
 };
+
+class NonFinalClass {
+    public static function staticMethod(): ?int // error: Declared return type int|null contains null, but it is never returned. Returned types: 1.
+    {
+        return 1;
+    }
+
+    final public function finalMethod(): ?int // error: Declared return type int|null contains null, but it is never returned. Returned types: 1.
+    {
+        return 1;
+    }
+
+    private function privateMethod(): ?int // error: Declared return type int|null contains null, but it is never returned. Returned types: 1.
+    {
+        return 1;
+    }
+
+    public function publicMethod(): ?int
+    {
+        return 1;
+    }
+
+    protected function protectedMethod(): ?int
+    {
+        return 1;
+    }
+}


### PR DESCRIPTION
This rule triggers false positives for methods that could be overridden. If any inheritor could return `null` then the parent method must declare it in the return type even if it doesn't return it.

We use Slevomat's `RequireAbstractOrFinal` so most our classes are final. The current behavior is not affected in these cases. The change is only in non-final, non-private, non-static methods which are almost always overridden in our case.