### PR TITLE
Skip static properties in `EnforceReadonlyPublicPropertyRule`

### DIFF
--- a/src/Rule/EnforceReadonlyPublicPropertyRule.php
+++ b/src/Rule/EnforceReadonlyPublicPropertyRule.php
@@ -41,7 +41,7 @@ class EnforceReadonlyPublicPropertyRule implements Rule
             return [];
         }
 
-        if (!$node->isPublic() || $node->isReadOnly() || $node->hasHooks() || $node->isPrivateSet() || $node->isProtectedSet()) {
+        if (!$node->isPublic() || $node->isReadOnly() || $node->hasHooks() || $node->isPrivateSet() || $node->isProtectedSet() || $node->isStatic()) {
             return [];
         }
 

--- a/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-81.php
+++ b/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-81.php
@@ -12,6 +12,8 @@ trait MyTrait {
 
     private string $private;
 
+    public static string $static;
+
 }
 
 class MyClass {
@@ -25,6 +27,8 @@ class MyClass {
     protected int $baz;
 
     private int $bag;
+
+    public static string $static;
 
 }
 

--- a/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-84.php
+++ b/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-84.php
@@ -14,6 +14,8 @@ trait MyTrait {
 
     private string $private;
 
+    public static string $static;
+
 }
 
 class MyClass {
@@ -29,6 +31,8 @@ class MyClass {
     protected int $baz;
 
     private int $bag;
+
+    public static string $static;
 
 }
 


### PR DESCRIPTION
Static properties cannot be marked as `readonly`. See note in PHP docs: https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.readonly-properties