### PR TITLE
Fix two more false positives in `EnforceReadonlyPublicPropertyRule`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,18 @@ class NoNativeReturnTypehint {
 - Ensures immutability of all public properties by enforcing `readonly` modifier
 - No modifier needed for readonly classes in PHP 8.2
 - Does nothing if PHP version does not support readonly properties (PHP 8.0 and below)
+- Can be configured to exclude properties with a default value
 ```php
 class EnforceReadonlyPublicPropertyRule {
     public int $foo; // fails, no readonly modifier
     public readonly int $bar;
 }
+```
+```neon
+parameters:
+    shipmonkRules:
+        enforceReadonlyPublicProperty:
+            excludePropertyWithDefaultValue: true # defaults to false
 ```
 
 ### forbidArithmeticOperationOnNonNumber

--- a/rules.neon
+++ b/rules.neon
@@ -22,6 +22,7 @@ parameters:
             enabled: %shipmonkRules.enableAllRules%
         enforceReadonlyPublicProperty:
             enabled: %shipmonkRules.enableAllRules%
+            excludePropertyWithDefaultValue: false
         forbidArithmeticOperationOnNonNumber:
             enabled: %shipmonkRules.enableAllRules%
             allowNumericString: false
@@ -121,6 +122,7 @@ parametersSchema:
         ])
         enforceReadonlyPublicProperty: structure([
             enabled: bool()
+            excludePropertyWithDefaultValue: bool()
         ])
         forbidArithmeticOperationOnNonNumber: structure([
             enabled: bool()
@@ -325,6 +327,8 @@ services:
             treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
     -
         class: ShipMonk\PHPStan\Rule\EnforceReadonlyPublicPropertyRule
+        arguments:
+            excludePropertyWithDefaultValue: %shipmonkRules.enforceReadonlyPublicProperty.excludePropertyWithDefaultValue%
     -
         class: ShipMonk\PHPStan\Rule\ForbidArithmeticOperationOnNonNumberRule
         arguments:

--- a/src/Rule/EnforceReadonlyPublicPropertyRule.php
+++ b/src/Rule/EnforceReadonlyPublicPropertyRule.php
@@ -16,10 +16,16 @@ use PHPStan\Rules\RuleErrorBuilder;
 class EnforceReadonlyPublicPropertyRule implements Rule
 {
 
+    private bool $excludePropertyWithDefaultValue;
+
     private PhpVersion $phpVersion;
 
-    public function __construct(PhpVersion $phpVersion)
+    public function __construct(
+        bool $excludePropertyWithDefaultValue,
+        PhpVersion $phpVersion
+    )
     {
+        $this->excludePropertyWithDefaultValue = $excludePropertyWithDefaultValue;
         $this->phpVersion = $phpVersion;
     }
 
@@ -48,8 +54,8 @@ class EnforceReadonlyPublicPropertyRule implements Rule
             || $node->isPrivateSet()
             || $node->isProtectedSet()
             || $node->isStatic()
-            || $node->getDefault() !== null
             || $node->getNativeType() === null
+            || ($this->excludePropertyWithDefaultValue && $node->getDefault() !== null)
         ) {
             return [];
         }

--- a/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
+++ b/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\PHPStan\Rule;
 
+use LogicException;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
@@ -13,12 +14,24 @@ use const PHP_VERSION_ID;
 class EnforceReadonlyPublicPropertyRuleTest extends RuleTestCase
 {
 
+    private ?bool $excludePropertyWithDefaultValue = null;
+
     private ?PhpVersion $phpVersion = null;
 
     protected function getRule(): Rule
     {
-        self::assertNotNull($this->phpVersion);
-        return new EnforceReadonlyPublicPropertyRule($this->phpVersion);
+        if ($this->excludePropertyWithDefaultValue === null) {
+            throw new LogicException('excludePropertyWithDefaultValue must be set');
+        }
+
+        if ($this->phpVersion === null) {
+            throw new LogicException('phpVersion must be set');
+        }
+
+        return new EnforceReadonlyPublicPropertyRule(
+            $this->excludePropertyWithDefaultValue,
+            $this->phpVersion,
+        );
     }
 
     public function testPhp84(): void
@@ -27,20 +40,30 @@ class EnforceReadonlyPublicPropertyRuleTest extends RuleTestCase
             self::markTestSkipped('PHP7 parser fails with property hooks');
         }
 
+        $this->excludePropertyWithDefaultValue = false;
         $this->phpVersion = $this->createPhpVersion(80_400);
         $this->analyseFile(__DIR__ . '/data/EnforceReadonlyPublicPropertyRule/code-84.php');
     }
 
     public function testPhp81(): void
     {
+        $this->excludePropertyWithDefaultValue = false;
         $this->phpVersion = $this->createPhpVersion(80_100);
         $this->analyseFile(__DIR__ . '/data/EnforceReadonlyPublicPropertyRule/code-81.php');
     }
 
     public function testPhp80(): void
     {
+        $this->excludePropertyWithDefaultValue = false;
         $this->phpVersion = $this->createPhpVersion(80_000);
         $this->analyseFile(__DIR__ . '/data/EnforceReadonlyPublicPropertyRule/code-80.php');
+    }
+
+    public function testExcludePropertyWithDefaultValue(): void
+    {
+        $this->excludePropertyWithDefaultValue = true;
+        $this->phpVersion = $this->createPhpVersion(80_100);
+        $this->analyseFile(__DIR__ . '/data/EnforceReadonlyPublicPropertyRule/exclude-property-with-default-value.php');
     }
 
     private function createPhpVersion(int $version): PhpVersion

--- a/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-81.php
+++ b/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-81.php
@@ -14,7 +14,7 @@ trait MyTrait {
 
     public static string $static;
 
-    public int $default = 42;
+    public int $default = 42; // error: Public property `default` not marked as readonly.
 
     public $untyped;
 
@@ -34,7 +34,7 @@ class MyClass {
 
     public static string $static;
 
-    public int $quux = 7;
+    public int $quux = 7; // error: Public property `quux` not marked as readonly.
 
     public $quuz;
 

--- a/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-84.php
+++ b/tests/Rule/data/EnforceReadonlyPublicPropertyRule/code-84.php
@@ -16,7 +16,7 @@ trait MyTrait {
 
     public static string $static;
 
-    public int $default = 42;
+    public int $default = 42; // error: Public property `default` not marked as readonly.
 
     public $untyped;
 
@@ -38,7 +38,7 @@ class MyClass {
 
     public static string $static;
 
-    public int $quux = 7;
+    public int $quux = 7; // error: Public property `quux` not marked as readonly.
 
     public $quuz;
 

--- a/tests/Rule/data/EnforceReadonlyPublicPropertyRule/exclude-property-with-default-value.php
+++ b/tests/Rule/data/EnforceReadonlyPublicPropertyRule/exclude-property-with-default-value.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace EnforceReadonlyPublicPropertyRuleExcludePropertyWithDefaultValue;
+
+trait MyTrait {
+
+    public ?string $public; // error: Public property `public` not marked as readonly.
+
+    public int $default = 42;
+
+}
+
+class MyClass {
+
+    use MyTrait;
+
+    public ?int $foo; // error: Public property `foo` not marked as readonly.
+
+    public int $quux = 7;
+
+}
+


### PR DESCRIPTION
_Thanks for merging my previous patch so quickly!_

Two more small fixes to the same rule:

1) Readonly properties cannot be initialized with an explicit default value.

>  Specifying an explicit default value on readonly properties is not allowed, because a readonly property with a default value is essentially the same as a constant, and thus not particularly useful. 

2) Untyped properties cannot be readonly.

> The readonly modifier can only be applied to [typed properties](https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.typed-properties). A readonly property without type constraints can be created using the [Mixed](https://www.php.net/manual/en/language.types.mixed.php) type.

https://www.php.net/manual/en/language.oop5.properties.php#language.oop5.properties.readonly-properties