### PR TITLE
Add EnforceNativePropertyTypehintRule

### DIFF
--- a/rules.neon
+++ b/rules.neon
@@ -18,6 +18,8 @@ parameters:
             enabled: %shipmonkRules.enableAllRules%
         enforceListReturn:
             enabled: %shipmonkRules.enableAllRules%
+        enforceNativePropertyTypehint:
+            enabled: %shipmonkRules.enableAllRules%
         enforceNativeReturnTypehint:
             enabled: %shipmonkRules.enableAllRules%
         enforceReadonlyPublicProperty:
@@ -114,6 +116,9 @@ parametersSchema:
             enabled: bool()
         ])
         enforceListReturn: structure([
+            enabled: bool()
+        ])
+        enforceNativePropertyTypehint: structure([
             enabled: bool()
         ])
         enforceNativeReturnTypehint: structure([
@@ -230,6 +235,8 @@ conditionalTags:
         phpstan.rules.rule: %shipmonkRules.enforceEnumMatch.enabled%
     ShipMonk\PHPStan\Rule\EnforceIteratorToArrayPreserveKeysRule:
         phpstan.rules.rule: %shipmonkRules.enforceIteratorToArrayPreserveKeys.enabled%
+    ShipMonk\PHPStan\Rule\EnforceNativePropertyTypehintRule:
+        phpstan.rules.rule: %shipmonkRules.enforceNativePropertyTypehint.enabled%
     ShipMonk\PHPStan\Rule\EnforceNativeReturnTypehintRule:
         phpstan.rules.rule: %shipmonkRules.enforceNativeReturnTypehint.enabled%
     ShipMonk\PHPStan\Rule\EnforceListReturnRule:
@@ -319,6 +326,10 @@ services:
         class: ShipMonk\PHPStan\Rule\EnforceIteratorToArrayPreserveKeysRule
     -
         class: ShipMonk\PHPStan\Rule\EnforceListReturnRule
+    -
+        class: ShipMonk\PHPStan\Rule\EnforceNativePropertyTypehintRule
+        arguments:
+            treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
     -
         class: ShipMonk\PHPStan\Rule\EnforceNativeReturnTypehintRule
         arguments:

--- a/src/Rule/EnforceNativePropertyTypehintRule.php
+++ b/src/Rule/EnforceNativePropertyTypehintRule.php
@@ -1,0 +1,362 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Analyser\Scope;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\FileTypeMapper;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\StaticType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VerbosityLevel;
+use function count;
+use function implode;
+use function in_array;
+use function sprintf;
+
+/**
+ * @implements Rule<Property>
+ */
+class EnforceNativePropertyTypehintRule implements Rule
+{
+
+    private FileTypeMapper $fileTypeMapper;
+
+    private PhpVersion $phpVersion;
+
+    private bool $treatPhpDocTypesAsCertain;
+
+    public function __construct(
+        FileTypeMapper $fileTypeMapper,
+        PhpVersion $phpVersion,
+        bool $treatPhpDocTypesAsCertain
+    )
+    {
+        $this->fileTypeMapper = $fileTypeMapper;
+        $this->phpVersion = $phpVersion;
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
+    }
+
+    public function getNodeType(): string
+    {
+        return Property::class;
+    }
+
+    /**
+     * @param Property $node
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(
+        Node $node,
+        Scope $scope
+    ): array
+    {
+        if ($this->treatPhpDocTypesAsCertain === false) {
+            return [];
+        }
+
+        if ($node->type !== null) {
+            return [];
+        }
+
+        if ($scope->isInTrait()) {
+            return []; // type may easily differ for each usage
+        }
+
+        if ($this->phpVersion->getVersionId() < 70_400) {
+            return []; // typed properties not available
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return [];
+        }
+
+        $phpDocType = $this->getPhpDocVarType($node, $scope);
+
+        if ($phpDocType === null) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($node->props as $prop) {
+            $propertyName = $prop->name->name;
+
+            if ($this->isPropertyDeclaredInParent($propertyName, $scope)) {
+                continue; // avoid LSP issues
+            }
+
+            $typeHint = $this->getTypehintByType($phpDocType, $scope, true);
+
+            if ($typeHint === null) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(sprintf('Missing native property typehint %s', $typeHint))
+                ->identifier('shipmonk.missingNativePropertyTypehint')
+                ->line($prop->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function getPhpDocVarType(Property $node, Scope $scope): ?Type
+    {
+        $docComment = $node->getDocComment();
+
+        if ($docComment === null) {
+            return null;
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return null;
+        }
+
+        $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+            $scope->getFile(),
+            $classReflection->getName(),
+            $scope->getTraitReflection() === null ? null : $scope->getTraitReflection()->getName(),
+            null,
+            $docComment->getText(),
+        );
+
+        $varTags = $resolvedPhpDoc->getVarTags();
+
+        foreach ($varTags as $varTag) {
+            return $varTag->getType();
+        }
+
+        return null;
+    }
+
+    private function isPropertyDeclaredInParent(string $propertyName, Scope $scope): bool
+    {
+        $classReflection = $scope->getClassReflection();
+
+        if ($classReflection === null) {
+            return false;
+        }
+
+        $parent = $classReflection->getParentClass();
+
+        while ($parent !== null) {
+            if ($parent->hasNativeProperty($propertyName)) {
+                return true;
+            }
+
+            $parent = $parent->getParentClass();
+        }
+
+        return false;
+    }
+
+    private function getTypehintByType(
+        Type $type,
+        Scope $scope,
+        bool $topLevel
+    ): ?string
+    {
+        if ($type instanceof MixedType || $this->isUnionTypeWithMixed($type)) {
+            return $this->phpVersion->getVersionId() >= 80_000 ? 'mixed' : null;
+        }
+
+        if ($type->isNull()->yes()) {
+            if (!$topLevel || $this->phpVersion->getVersionId() >= 80_200) {
+                return 'null';
+            }
+
+            return null;
+        }
+
+        // Check union types first (handles nullable unions properly)
+        if ($type instanceof UnionType) {
+            return $this->getUnionTypehint($type, $scope);
+        }
+
+        // Check intersection types before other type checks
+        if ($type instanceof IntersectionType) { // @phpstan-ignore phpstanApi.instanceofType
+            return $this->getIntersectionTypehint($type, $scope);
+        }
+
+        $typeWithoutNull = TypeCombinator::removeNull($type);
+        $typeHint = null;
+
+        if ((new BooleanType())->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {
+            if (($typeWithoutNull->isTrue()->yes() || $typeWithoutNull->isFalse()->yes()) && $this->phpVersion->getVersionId() >= 80_200) {
+                $typeHint = $typeWithoutNull->describe(VerbosityLevel::typeOnly());
+            } else {
+                $typeHint = 'bool';
+            }
+        } elseif ((new IntegerType())->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {
+            $typeHint = 'int';
+        } elseif ((new FloatType())->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {
+            $typeHint = 'float';
+        } elseif ((new ArrayType(new MixedType(), new MixedType()))->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {
+            $typeHint = 'array';
+        } elseif ((new StringType())->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {
+            $typeHint = 'string';
+        } elseif ($typeWithoutNull instanceof StaticType) {
+            $typeHint = 'self'; // properties cannot use static keyword
+        } elseif (count($typeWithoutNull->getObjectClassNames()) === 1) {
+            $className = $typeWithoutNull->getObjectClassNames()[0];
+
+            if ($className === $this->getClassName($scope)) {
+                $typeHint = 'self';
+            } else {
+                $typeHint = '\\' . $className;
+            }
+        } elseif ((new IterableType(new MixedType(), new MixedType()))->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {
+            $typeHint = 'iterable';
+        } elseif ((new ObjectWithoutClassType())->accepts($typeWithoutNull, $scope->isDeclareStrictTypes())->yes()) {
+            $typeHint = 'object';
+        }
+
+        if ($typeHint !== null && TypeCombinator::containsNull($type)) {
+            $typeHint = '?' . $typeHint;
+        }
+
+        return $typeHint;
+    }
+
+    private function getClassName(Scope $scope): ?string
+    {
+        if ($scope->getClassReflection() === null) {
+            return null;
+        }
+
+        return $scope->getClassReflection()->getName();
+    }
+
+    private function getUnionTypehint(
+        Type $type,
+        Scope $scope
+    ): ?string
+    {
+        if (!$type instanceof UnionType) {
+            return null;
+        }
+
+        // Handle nullable types specially for PHP < 8.0
+        if (!$this->phpVersion->supportsNativeUnionTypes()) {
+            // Check if this is a simple nullable type (T|null with exactly 2 types)
+            $types = $type->getTypes();
+
+            if (count($types) === 2 && TypeCombinator::containsNull($type)) {
+                $typeWithoutNull = TypeCombinator::removeNull($type);
+                $innerHint = $this->getTypehintByType($typeWithoutNull, $scope, false);
+
+                if ($innerHint !== null) {
+                    return '?' . $innerHint;
+                }
+            }
+
+            return null;
+        }
+
+        $typehintParts = [];
+
+        foreach ($type->getTypes() as $subtype) {
+            $wrap = false;
+
+            if ($subtype instanceof IntersectionType) { // @phpstan-ignore phpstanApi.instanceofType
+                if ($this->phpVersion->getVersionId() < 80_200) { // DNF
+                    return null;
+                }
+
+                $wrap = true;
+            }
+
+            $subtypeHint = $this->getTypehintByType($subtype, $scope, false);
+
+            if ($subtypeHint === null) {
+                return null;
+            }
+
+            if (in_array($subtypeHint, $typehintParts, true)) {
+                continue;
+            }
+
+            $typehintParts[] = $wrap ? "($subtypeHint)" : $subtypeHint;
+        }
+
+        return implode('|', $typehintParts);
+    }
+
+    private function getIntersectionTypehint(
+        Type $type,
+        Scope $scope
+    ): ?string
+    {
+        if (!$type instanceof IntersectionType) { // @phpstan-ignore phpstanApi.instanceofType
+            return null;
+        }
+
+        if (!$this->phpVersion->supportsPureIntersectionTypes()) {
+            return null;
+        }
+
+        $typehintParts = [];
+
+        foreach ($type->getTypes() as $subtype) {
+            $wrap = false;
+
+            if ($subtype instanceof UnionType) {
+                if ($this->phpVersion->getVersionId() < 80_200) { // DNF
+                    return null;
+                }
+
+                $wrap = true;
+            }
+
+            $subtypeHint = $this->getTypehintByType($subtype, $scope, false);
+
+            if ($subtypeHint === null) {
+                return null;
+            }
+
+            if (in_array($subtypeHint, $typehintParts, true)) {
+                continue;
+            }
+
+            $typehintParts[] = $wrap ? "($subtypeHint)" : $subtypeHint;
+        }
+
+        return implode('&', $typehintParts);
+    }
+
+    private function isUnionTypeWithMixed(Type $type): bool
+    {
+        if (!$type instanceof UnionType) {
+            return false;
+        }
+
+        foreach ($type->getTypes() as $innerType) {
+            if ($innerType instanceof MixedType) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/tests/Rule/EnforceNativePropertyTypehintRuleTest.php
+++ b/tests/Rule/EnforceNativePropertyTypehintRuleTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan\Rule;
+
+use PHPStan\Php\PhpVersion;
+use PHPStan\Rules\Rule;
+use PHPStan\Type\FileTypeMapper;
+use ShipMonk\PHPStan\RuleTestCase;
+use const PHP_VERSION_ID;
+
+/**
+ * @extends RuleTestCase<EnforceNativePropertyTypehintRule>
+ */
+class EnforceNativePropertyTypehintRuleTest extends RuleTestCase
+{
+
+    private ?PhpVersion $phpVersion = null;
+
+    protected function getRule(): Rule
+    {
+        self::assertNotNull($this->phpVersion);
+
+        return new EnforceNativePropertyTypehintRule(
+            self::getContainer()->getByType(FileTypeMapper::class),
+            $this->phpVersion,
+            true,
+        );
+    }
+
+    public function testPhp74(): void
+    {
+        $this->phpVersion = $this->createPhpVersion(70_400);
+        $this->analyseFile(__DIR__ . '/data/EnforceNativePropertyTypehintRule/code-74.php');
+    }
+
+    public function testPhp80(): void
+    {
+        $this->phpVersion = $this->createPhpVersion(80_000);
+        $this->analyseFile(__DIR__ . '/data/EnforceNativePropertyTypehintRule/code-80.php');
+    }
+
+    public function testPhp81(): void
+    {
+        if (PHP_VERSION_ID < 80_100) {
+            self::markTestSkipped('Requires PHP 8.1');
+        }
+
+        $this->phpVersion = $this->createPhpVersion(80_100);
+        $this->analyseFile(__DIR__ . '/data/EnforceNativePropertyTypehintRule/code-81.php');
+    }
+
+    public function testPhp82(): void
+    {
+        if (PHP_VERSION_ID < 80_100) {
+            self::markTestSkipped('Requires PHP 8.1');
+        }
+
+        $this->phpVersion = $this->createPhpVersion(80_200);
+        $this->analyseFile(__DIR__ . '/data/EnforceNativePropertyTypehintRule/code-82.php');
+    }
+
+    public function testParent(): void
+    {
+        $this->phpVersion = $this->createPhpVersion(80_000);
+        $this->analyseFile(__DIR__ . '/data/EnforceNativePropertyTypehintRule/code-parent.php');
+    }
+
+    private function createPhpVersion(int $version): PhpVersion
+    {
+        return new PhpVersion($version);
+    }
+
+}

--- a/tests/Rule/data/EnforceNativePropertyTypehintRule/code-74.php
+++ b/tests/Rule/data/EnforceNativePropertyTypehintRule/code-74.php
@@ -1,0 +1,91 @@
+<?php declare(strict_types = 1);
+
+namespace EnforceNativePropertyTypehintRule74;
+
+class A {}
+
+class BasicTypes {
+
+    /** @var int */
+    public $shouldHaveInt; // error: Missing native property typehint int
+
+    /** @var string */
+    public $shouldHaveString; // error: Missing native property typehint string
+
+    /** @var bool */
+    public $shouldHaveBool; // error: Missing native property typehint bool
+
+    /** @var float */
+    public $shouldHaveFloat; // error: Missing native property typehint float
+
+    /** @var array */
+    public $shouldHaveArray; // error: Missing native property typehint array
+
+    /** @var list<string> */
+    public $shouldHaveArray2; // no error - list is not representable as array in native type
+
+    /** @var array<int, string> */
+    public $shouldHaveArray3; // error: Missing native property typehint array
+
+    /** @var array{id: int} */
+    public $shouldHaveArray4; // error: Missing native property typehint array
+
+    /** @var object */
+    public $shouldHaveObject; // error: Missing native property typehint object
+
+    /** @var iterable */
+    public $shouldHaveIterable; // error: Missing native property typehint iterable
+
+    /** @var self */
+    public $shouldHaveSelf; // error: Missing native property typehint self
+
+    /** @var A */
+    public $shouldHaveClass; // error: Missing native property typehint \EnforceNativePropertyTypehintRule74\A
+
+    /** @var \stdClass */
+    public $shouldHaveStdClass; // error: Missing native property typehint \stdClass
+
+    /** @var ?int */
+    public $shouldHaveNullableInt; // error: Missing native property typehint ?int
+
+    /** @var int|null */
+    public $shouldHaveNullableInt2; // error: Missing native property typehint ?int
+
+    /** @var ?string */
+    public $shouldHaveNullableString; // error: Missing native property typehint ?string
+
+    /** @var ?A */
+    public $shouldHaveNullableClass; // error: Missing native property typehint ?\EnforceNativePropertyTypehintRule74\A
+
+    /** @var class-string */
+    public $shouldHaveString2; // error: Missing native property typehint string
+
+    // Should NOT report - already has type
+    public int $hasType;
+
+    // Should NOT report - no @var annotation
+    public $noPhpDoc;
+
+    // Should NOT report - union type not available in 7.4
+    /** @var string|int */
+    public $unionType;
+
+    // Should NOT report - mixed not available in 7.4
+    /** @var mixed */
+    public $mixedType;
+
+    // Should NOT report - null standalone not available in 7.4
+    /** @var null */
+    public $nullType;
+
+    // Should NOT report - callable not allowed for properties
+    /** @var callable */
+    public $callableType;
+
+}
+
+trait MyTrait {
+    // Should NOT report - in trait
+    /** @var int */
+    public $traitProperty;
+}

--- a/tests/Rule/data/EnforceNativePropertyTypehintRule/code-80.php
+++ b/tests/Rule/data/EnforceNativePropertyTypehintRule/code-80.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace EnforceNativePropertyTypehintRule80;
+
+class A {}
+class B {}
+
+class UnionAndMixedTypes {
+
+    /** @var mixed */
+    public $shouldHaveMixed; // error: Missing native property typehint mixed
+
+    /** @var string|int */
+    public $shouldHaveUnion; // error: Missing native property typehint string|int
+
+    /** @var string|int|null */
+    public $shouldHaveNullableUnion; // error: Missing native property typehint string|int|null
+
+    /** @var A|B */
+    public $shouldHaveObjectUnion; // error: Missing native property typehint \EnforceNativePropertyTypehintRule80\A|\EnforceNativePropertyTypehintRule80\B
+
+    /** @var A|B|null */
+    public $shouldHaveNullableObjectUnion; // error: Missing native property typehint \EnforceNativePropertyTypehintRule80\A|\EnforceNativePropertyTypehintRule80\B|null
+
+    /** @var A|string */
+    public $shouldHaveMixedUnion; // error: Missing native property typehint \EnforceNativePropertyTypehintRule80\A|string
+
+    /** @var A|string|null */
+    public $shouldHaveNullableMixedUnion; // error: Missing native property typehint \EnforceNativePropertyTypehintRule80\A|string|null
+
+    /** @var static */
+    public $shouldHaveSelf; // error: Missing native property typehint self
+
+    // Should NOT report - intersection not available in 8.0
+    /** @var \Countable&\Iterator */
+    public $intersectionType;
+
+    // Should NOT report - null standalone not available in 8.0
+    /** @var null */
+    public $nullType;
+
+    // Should report bool - true/false standalone not available in 8.0
+    /** @var true */
+    public $trueType; // error: Missing native property typehint bool
+
+    /** @var false */
+    public $falseType; // error: Missing native property typehint bool
+
+    // Should NOT report - callable not allowed for properties
+    /** @var callable */
+    public $callableType;
+
+    // Should report - basic types still work
+    /** @var int */
+    public $shouldHaveInt; // error: Missing native property typehint int
+
+}

--- a/tests/Rule/data/EnforceNativePropertyTypehintRule/code-81.php
+++ b/tests/Rule/data/EnforceNativePropertyTypehintRule/code-81.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace EnforceNativePropertyTypehintRule81;
+
+interface I {}
+interface J {}
+
+class IntersectionTypes {
+
+    /** @var I&J */
+    public $shouldHaveIntersection; // error: Missing native property typehint \EnforceNativePropertyTypehintRule81\I&\EnforceNativePropertyTypehintRule81\J
+
+    /** @var \Countable&\Iterator */
+    public $shouldHaveBuiltinIntersection; // error: Missing native property typehint \Countable&\Iterator
+
+    // Should NOT report - DNF not available in 8.1
+    /** @var (I&J)|null */
+    public $dnfType;
+
+    // Should NOT report - null standalone not available in 8.1
+    /** @var null */
+    public $nullType;
+
+    // Should report bool - true/false standalone not available in 8.1
+    /** @var true */
+    public $trueType; // error: Missing native property typehint bool
+
+    // Basic types should still work
+    /** @var int */
+    public $shouldHaveInt; // error: Missing native property typehint int
+
+    /** @var mixed */
+    public $shouldHaveMixed; // error: Missing native property typehint mixed
+
+    /** @var string|int */
+    public $shouldHaveUnion; // error: Missing native property typehint string|int
+
+}

--- a/tests/Rule/data/EnforceNativePropertyTypehintRule/code-82.php
+++ b/tests/Rule/data/EnforceNativePropertyTypehintRule/code-82.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace EnforceNativePropertyTypehintRule82;
+
+interface I {}
+interface J {}
+class A implements I {}
+class B implements I {}
+
+class DnfAndStandaloneTypes {
+
+    /** @var null */
+    public $shouldHaveNull; // error: Missing native property typehint null
+
+    /** @var true */
+    public $shouldHaveTrue; // error: Missing native property typehint true
+
+    /** @var false */
+    public $shouldHaveFalse; // error: Missing native property typehint false
+
+    /** @var (A&I)|B */
+    public $shouldHaveDnf; // error: Missing native property typehint \EnforceNativePropertyTypehintRule82\A|\EnforceNativePropertyTypehintRule82\B
+
+    /** @var (A&I)|null */
+    public $shouldHaveNullableDnf; // error: Missing native property typehint \EnforceNativePropertyTypehintRule82\A|null
+
+    /** @var true|null */
+    public $shouldHaveNullableTrue; // error: Missing native property typehint true|null
+
+    /** @var false|null */
+    public $shouldHaveNullableFalse; // error: Missing native property typehint false|null
+
+    // Basic types should still work
+    /** @var int */
+    public $shouldHaveInt; // error: Missing native property typehint int
+
+    /** @var I&J */
+    public $shouldHaveIntersection; // error: Missing native property typehint \EnforceNativePropertyTypehintRule82\I&\EnforceNativePropertyTypehintRule82\J
+
+    /** @var string|int */
+    public $shouldHaveUnion; // error: Missing native property typehint string|int
+
+}

--- a/tests/Rule/data/EnforceNativePropertyTypehintRule/code-parent.php
+++ b/tests/Rule/data/EnforceNativePropertyTypehintRule/code-parent.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace EnforceNativePropertyTypehintRuleParent;
+
+class ParentClass {
+
+    /** @var int */
+    public $typedInParent; // error: Missing native property typehint int
+
+    public int $alreadyTyped;
+
+    public $untypedInParent;
+
+    /** @var string */
+    public $newPropertyInParent; // error: Missing native property typehint string
+
+}
+
+class ChildClass extends ParentClass {
+
+    // Should NOT report - property from parent (LSP)
+    /** @var int */
+    public $typedInParent;
+
+    // Should NOT report - parent already has type
+    public int $alreadyTyped;
+
+    // Should NOT report - property from parent (LSP)
+    /** @var string */
+    public $untypedInParent;
+
+    // Should report - new property in child
+    /** @var bool */
+    public $newProperty; // error: Missing native property typehint bool
+
+}
+
+class GrandchildClass extends ChildClass {
+
+    // Should NOT report - property from parent hierarchy (LSP)
+    /** @var int */
+    public $typedInParent;
+
+    // Should NOT report - property from parent hierarchy (LSP)
+    /** @var bool */
+    public $newProperty;
+
+    // Should report - new property in grandchild
+    /** @var float */
+    public $grandchildProperty; // error: Missing native property typehint float
+
+}


### PR DESCRIPTION
## Summary
New PHPStan rule that enforces native PHP type hints on class properties when a `@var` PhpDoc annotation exists and a native type is representable.

### Features
- **PHP version aware**: suggests types available for configured PHP version
  - PHP 7.4+: basic typed properties (int, string, bool, float, array, object, iterable, self, ?T)
  - PHP 8.0+: mixed, union types
  - PHP 8.1+: intersection types
  - PHP 8.2+: null, true, false standalone, DNF types
- **LSP safe**: skips properties inherited from parent classes to avoid breaking inheritance
- **Trait safe**: skips properties in traits (type may vary by usage)
- **PhpDoc driven**: only suggests types when `@var` annotation exists

### Configuration
```neon
parameters:
    shipmonkRules:
        enforceNativePropertyTypehint:
            enabled: true  # default when enableAllRules is true
```

### Error identifier
`shipmonk.missingNativePropertyTypehint`

### Example
```php
class Example {
    /** @var int */
    public $count;  // Error: Missing native property typehint int
    
    /** @var string|int */
    public $value;  // Error on PHP 8.0+: Missing native property typehint string|int
    
    public int $typed;  // OK - already has native type
    
    public $noDoc;  // OK - no @var annotation
}
```

## Test plan
- [x] Added test cases for PHP 7.4, 8.0, 8.1, 8.2 with version-specific type suggestions
- [x] Added test cases for parent class compatibility (LSP)
- [x] All 65 tests pass
- [x] PHPStan analysis passes