### PR TITLE
Add composer.lock to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 /bin export-ignore
 /cache export-ignore
 /tests export-ignore
+/composer.lock export-ignore
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.github export-ignore


### PR DESCRIPTION
## Summary
- Add `composer.lock export-ignore` to `.gitattributes` to exclude it from release archives

Since `composer.lock` is not in `.gitignore` (it's committed to the repository), it should be added as `export-ignore` so it doesn't get included in release archives downloaded via Composer.