### PR TITLE
forbidVariableTypeOverwriting: fix false positive with fluent `$this` returns

### DIFF
--- a/src/Rule/ForbidVariableTypeOverwritingRule.php
+++ b/src/Rule/ForbidVariableTypeOverwritingRule.php
@@ -16,6 +16,7 @@ use PHPStan\Type\GeneralizePrecision;
 use PHPStan\Type\IntegerRangeType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\StaticType;
 use PHPStan\Type\SubtractableType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -85,6 +86,10 @@ class ForbidVariableTypeOverwritingRule implements Rule
 
     private function generalize(Type $type): Type
     {
+        if ($type instanceof StaticType) {
+            $type = $type->getStaticObjectType(); // @phpstan-ignore shipmonk.variableTypeOverwritten
+        }
+
         if (
             $type->isConstantValue()->yes()
             || $type instanceof IntegerRangeType

--- a/tests/Rule/data/ForbidVariableTypeOverwritingRule/code.php
+++ b/tests/Rule/data/ForbidVariableTypeOverwritingRule/code.php
@@ -162,3 +162,62 @@ function testEnumCaseChange() {
 function testIntToInt(int $positive, int $negative) {
     $positive = $negative;
 }
+
+function testFloatToInt(float $float, int $int) {
+    $float = $int; // error: Overwriting variable $float while changing its type from float to int
+}
+
+function testIntToFloat(int $int, float $float) {
+    $int = $float; // error: Overwriting variable $int while changing its type from int to float
+}
+
+class FluentClass {
+    /** @return $this */
+    public function orderBy(): static {
+        return $this;
+    }
+
+    /** @return $this */
+    public function setFirstResult(): static {
+        return $this;
+    }
+
+    /** @return $this */
+    public function setMaxResults(): static {
+        return $this;
+    }
+}
+
+function testFluentInterfaceSameType(FluentClass $qb): void {
+    $qb = $qb
+        ->orderBy()
+        ->setFirstResult()
+        ->setMaxResults();
+}
+
+abstract class AbstractBuilder {
+    /** @return $this */
+    public function orderBy(): self {
+        return $this;
+    }
+
+    /** @return $this */
+    public function setFirstResult(): self {
+        return $this;
+    }
+
+    /** @return $this */
+    public function setMaxResults(): self {
+        return $this;
+    }
+}
+
+class ConcreteBuilder extends AbstractBuilder {
+}
+
+function testFluentInterfaceInherited(ConcreteBuilder $qb): void {
+    $qb = $qb
+        ->orderBy()
+        ->setFirstResult()
+        ->setMaxResults();
+}


### PR DESCRIPTION
Same as https://github.com/shipmonk-rnd/phpstan-rules/pull/348, but that MR has broken state in GitHub (unable to merge it)

Closes https://github.com/shipmonk-rnd/phpstan-rules/issues/347