### PR TITLE
forbidIncrementDecrementOnNonInteger: support BcMath\Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ parameters:
 ```
 
 ### forbidIncrementDecrementOnNonInteger
-- Denies using `$i++`, `$i--`, `++$i`, `--$i` with any non-integer
+- Denies using `$i++`, `$i--`, `++$i`, `--$i` with types other than `int` and `BcMath\Number`
 - PHP itself is leading towards stricter behaviour here and soft-deprecated **some** non-integer usages in 8.3, see [RFC](https://wiki.php.net/rfc/saner-inc-dec-operators)
 
 ```php

--- a/tests/Rule/ForbidIncrementDecrementOnNonIntegerRuleTest.php
+++ b/tests/Rule/ForbidIncrementDecrementOnNonIntegerRuleTest.php
@@ -2,8 +2,10 @@
 
 namespace ShipMonk\PHPStan\Rule;
 
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ForbidIncrementDecrementOnNonIntegerRule>
@@ -13,12 +15,23 @@ class ForbidIncrementDecrementOnNonIntegerRuleTest extends RuleTestCase
 
     protected function getRule(): Rule
     {
-        return new ForbidIncrementDecrementOnNonIntegerRule();
+        return new ForbidIncrementDecrementOnNonIntegerRule(
+            self::getContainer()->getByType(PhpVersion::class),
+        );
     }
 
     public function testClass(): void
     {
         $this->analyseFile(__DIR__ . '/data/ForbidIncrementDecrementOnNonIntegerRule/code.php');
+    }
+
+    public function testBcMathNumber(): void
+    {
+        if (PHP_VERSION_ID < 80_400) {
+            self::markTestSkipped('Requires PHP 8.4');
+        }
+
+        $this->analyseFile(__DIR__ . '/data/ForbidIncrementDecrementOnNonIntegerRule/bcmath-number.php');
     }
 
 }

--- a/tests/Rule/data/ForbidIncrementDecrementOnNonIntegerRule/bcmath-number.php
+++ b/tests/Rule/data/ForbidIncrementDecrementOnNonIntegerRule/bcmath-number.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace ForbidIncrementDecrementOnNonIntegerRule;
+
+use BcMath\Number;
+
+class IncDecBcMathNumber {
+    public function testPreDecrement(Number $x): void {
+        --$x;
+    }
+
+    public function testPostDecrement(Number $x): void {
+        $x--;
+    }
+
+    public function testPreIncrement(Number $x): void {
+        ++$x;
+    }
+
+    public function testPostIncrement(Number $x): void {
+        $x++;
+    }
+}


### PR DESCRIPTION
This adds support for `BcMath\Number` increment/decrement operators (on PHP >= 8.4)

```
php > $x = new BcMath\Number('3.14');
php > print $x;
3.14
php > $x++;
php > print $x;
4.14
```

As of phpstan 2.1.40, this is supported: https://phpstan.org/r/d2f000b7-4b86-45d4-9aba-7f0b302d7db5

However, these errors are emitted:

```
Using -- over non-integer (BcMath\Number)                               
         🪪  shipmonk.incrementDecrementOnNonInteger
etc...
```

I just added the required checks to `ForbidIncrementDecrementOnNonIntegerRule`, but...

* The rule name is weird after the changes. Would you prefer one of these instead:
  * Rename rule to something like `ForbidIncrementDecrementOnUnsafeTypesRule`?
  * Add parameter `allowBcMathNumber`?
* Would be nice to include tests for PHP < 8.4 too
  * What's the preferred way to achieve this? The simple way would be to use `$this->analyse($files, $errors)`