### PR TITLE
forbidUselessNullableReturn: fix false positive with property hooks

### DIFF
--- a/src/Rule/ForbidUselessNullableReturnRule.php
+++ b/src/Rule/ForbidUselessNullableReturnRule.php
@@ -5,6 +5,7 @@ namespace ShipMonk\PHPStan\Rule;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClosureReturnStatementsNode;
+use PHPStan\Node\PropertyHookReturnStatementsNode;
 use PHPStan\Node\ReturnStatementsNode;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\IdentifierRuleError;
@@ -36,6 +37,10 @@ class ForbidUselessNullableReturnRule implements Rule
         Scope $scope
     ): array
     {
+        if ($node instanceof PropertyHookReturnStatementsNode) {
+            return []; // hooks cannot have their own return type, it is inherited from the property
+        }
+
         $verbosity = VerbosityLevel::precise();
         $methodReflection = $scope->getFunction();
 

--- a/tests/Rule/ForbidUselessNullableReturnRuleTest.php
+++ b/tests/Rule/ForbidUselessNullableReturnRuleTest.php
@@ -4,6 +4,7 @@ namespace ShipMonk\PHPStan\Rule;
 
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ForbidUselessNullableReturnRule>
@@ -19,6 +20,15 @@ class ForbidUselessNullableReturnRuleTest extends RuleTestCase
     public function test(): void
     {
         $this->analyseFile(__DIR__ . '/data/ForbidUselessNullableReturnRule/code.php');
+    }
+
+    public function testPropertyHooks(): void
+    {
+        if (PHP_VERSION_ID < 8_00_00) {
+            self::markTestSkipped('PHP7 parser fails with property hooks');
+        }
+
+        $this->analyseFile(__DIR__ . '/data/ForbidUselessNullableReturnRule/code-hook.php');
     }
 
 }

--- a/tests/Rule/data/ForbidUselessNullableReturnRule/code-hook.php
+++ b/tests/Rule/data/ForbidUselessNullableReturnRule/code-hook.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ForbidUselessNullableReturnRuleHook;
+
+class HookedProperties {
+
+    public ?string $value = null {
+        get {
+            $this->value !== null || throw new \LogicException('No value set');
+
+            return $this->value;
+        }
+    }
+
+    public ?int $number = null {
+        get {
+            return $this->number;
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- Fixes #354
- Property hooks inherit their return type from the property and cannot declare their own, so the "useless nullable return" check was a false positive
- Skip `PropertyHookReturnStatementsNode` (same pattern as `EnforceNativeReturnTypehintRule`)

## Test plan
- [x] Added test with property hook that never returns null (the reported case)
- [x] Added test with property hook that does return null (no error expected either)
- [x] Existing tests still pass

Co-Authored-By: Claude Code