### PR TITLE
Defer reflection calls from constructors to first processNode() invocation

### DIFF
--- a/src/Rule/ClassSuffixNamingRule.php
+++ b/src/Rule/ClassSuffixNamingRule.php
@@ -26,6 +26,8 @@ class ClassSuffixNamingRule implements Rule
      */
     private array $superclassToSuffixMapping;
 
+    private bool $validated = false;
+
     /**
      * @param array<class-string, string> $superclassToSuffixMapping
      */
@@ -34,14 +36,22 @@ class ClassSuffixNamingRule implements Rule
         array $superclassToSuffixMapping = []
     )
     {
-        foreach ($superclassToSuffixMapping as $className => $suffix) {
-            if (!$reflectionProvider->hasClass($className)) {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->superclassToSuffixMapping = $superclassToSuffixMapping;
+    }
+
+    private function validateSuperclassToSuffixMapping(): void
+    {
+        if ($this->validated) {
+            return;
+        }
+
+        foreach ($this->superclassToSuffixMapping as $className => $suffix) {
+            if (!$this->reflectionProvider->hasClass($className)) {
                 throw new LogicException("Class $className used in 'superclassToSuffixMapping' does not exist");
             }
         }
-
-        $this->reflectionProvider = $reflectionProvider;
-        $this->superclassToSuffixMapping = $superclassToSuffixMapping;
+        $this->validated = true;
     }
 
     public function getNodeType(): string
@@ -58,6 +68,11 @@ class ClassSuffixNamingRule implements Rule
         Scope $scope
     ): array
     {
+        $this->validateSuperclassToSuffixMapping();
+        if ($this->superclassToSuffixMapping === []) {
+            return [];
+        }
+
         $classReflection = $scope->getClassReflection();
 
         if ($classReflection === null) {

--- a/src/Rule/ForbidCheckedExceptionInCallableRule.php
+++ b/src/Rule/ForbidCheckedExceptionInCallableRule.php
@@ -72,13 +72,18 @@ class ForbidCheckedExceptionInCallableRule implements Rule
     private array $callablesInArguments = [];
 
     /**
+     * @var array<string, int|list<int>>
+     */
+    private array $rawAllowedCheckedExceptionCallables;
+
+    /**
      * class::method => callable argument index
      * or
      * function => callable argument index
      *
-     * @var array<string, list<int>>
+     * @var array<string, list<int>>|null
      */
-    private array $callablesAllowingCheckedExceptions;
+    private ?array $callablesAllowingCheckedExceptions = null;
 
     /**
      * PHPStan's fiber-based processing no longer guarantees that CallLike nodes are processed before their Arg nodes.
@@ -99,17 +104,28 @@ class ForbidCheckedExceptionInCallableRule implements Rule
         array $allowedCheckedExceptionCallables
     )
     {
-        $this->checkClassExistence($reflectionProvider, $allowedCheckedExceptionCallables);
-
-        $this->callablesAllowingCheckedExceptions = array_map(
-            function ($argumentIndexes): array {
-                return $this->normalizeArgumentIndexes($argumentIndexes);
-            },
-            $allowedCheckedExceptionCallables,
-        );
+        $this->rawAllowedCheckedExceptionCallables = $allowedCheckedExceptionCallables;
         $this->exceptionTypeResolver = $exceptionTypeResolver;
         $this->reflectionProvider = $reflectionProvider;
         $this->nodeScopeResolver = $nodeScopeResolver;
+    }
+
+    /**
+     * @return array<string, list<int>>
+     */
+    private function getCallablesAllowingCheckedExceptions(): array
+    {
+        if ($this->callablesAllowingCheckedExceptions === null) {
+            $this->checkClassExistence($this->reflectionProvider, $this->rawAllowedCheckedExceptionCallables);
+            $this->callablesAllowingCheckedExceptions = array_map(
+                function ($argumentIndexes): array {
+                    return $this->normalizeArgumentIndexes($argumentIndexes);
+                },
+                $this->rawAllowedCheckedExceptionCallables,
+            );
+        }
+
+        return $this->callablesAllowingCheckedExceptions;
     }
 
     public function getNodeType(): string
@@ -385,7 +401,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
     ): bool
     {
         if ($caller === null) {
-            foreach ($this->callablesAllowingCheckedExceptions as $immediateFunction => $indexes) {
+            foreach ($this->getCallablesAllowingCheckedExceptions() as $immediateFunction => $indexes) {
                 if (strpos($immediateFunction, '::') !== false) {
                     continue;
                 }
@@ -402,7 +418,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
         }
 
         foreach ($caller->getObjectClassReflections() as $callerReflection) {
-            foreach ($this->callablesAllowingCheckedExceptions as $immediateCallerAndMethod => $indexes) {
+            foreach ($this->getCallablesAllowingCheckedExceptions() as $immediateCallerAndMethod => $indexes) {
                 if (strpos($immediateCallerAndMethod, '::') === false) {
                     continue;
                 }

--- a/src/Rule/ForbidCustomFunctionsRule.php
+++ b/src/Rule/ForbidCustomFunctionsRule.php
@@ -31,6 +31,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use function array_keys;
 use function array_map;
 use function count;
 use function explode;
@@ -54,6 +55,8 @@ class ForbidCustomFunctionsRule implements Rule
 
     private ReflectionProvider $reflectionProvider;
 
+    private bool $validated = false;
+
     /**
      * @param array<mixed, mixed> $forbiddenFunctions
      */
@@ -63,7 +66,6 @@ class ForbidCustomFunctionsRule implements Rule
     )
     {
         $this->reflectionProvider = $reflectionProvider;
-
         foreach ($forbiddenFunctions as $forbiddenFunction => $description) {
             if (!is_string($forbiddenFunction)) {
                 throw new LogicException("Unexpected forbidden function name, string expected, got $forbiddenFunction. Usage: ['var_dump' => 'Remove debug code!'].");
@@ -85,12 +87,22 @@ class ForbidCustomFunctionsRule implements Rule
                 throw new LogicException("Unexpected format of forbidden function {$forbiddenFunction}, expected Namespace\Class::methodName");
             }
 
-            if ($className !== self::FUNCTION && !$reflectionProvider->hasClass($className)) {
-                throw new LogicException("Class {$className} used in 'forbiddenFunctions' does not exist");
-            }
-
             $this->forbiddenFunctions[$className][$methodName] = $description;
         }
+    }
+
+    private function validateForbiddenFunctions(): void
+    {
+        if ($this->validated) {
+            return;
+        }
+
+        foreach (array_keys($this->forbiddenFunctions) as $className) {
+            if ($className !== self::FUNCTION && !$this->reflectionProvider->hasClass($className)) {
+                throw new LogicException("Class {$className} used in 'forbiddenFunctions' does not exist");
+            }
+        }
+        $this->validated = true;
     }
 
     public function getNodeType(): string
@@ -111,6 +123,7 @@ class ForbidCustomFunctionsRule implements Rule
         }
 
         if ($node instanceof FuncCall) {
+            $this->validateForbiddenFunctions();
             return $this->validateFunctionCall($node, $scope);
         }
 
@@ -131,6 +144,7 @@ class ForbidCustomFunctionsRule implements Rule
             return [];
         }
 
+        $this->validateForbiddenFunctions();
         $errors = [];
 
         foreach ($methodNames as $methodName) {

--- a/src/Rule/ForbidIdenticalClassComparisonRule.php
+++ b/src/Rule/ForbidIdenticalClassComparisonRule.php
@@ -27,10 +27,14 @@ class ForbidIdenticalClassComparisonRule implements Rule
 
     private const DEFAULT_BLACKLIST = [DateTimeInterface::class];
 
+    private ReflectionProvider $reflectionProvider;
+
     /**
      * @var array<int, class-string<object>>
      */
     private array $blacklist;
+
+    private bool $validated = false;
 
     /**
      * @param array<int, class-string<object>> $blacklist
@@ -40,13 +44,22 @@ class ForbidIdenticalClassComparisonRule implements Rule
         array $blacklist = self::DEFAULT_BLACKLIST
     )
     {
-        foreach ($blacklist as $className) {
-            if (!$reflectionProvider->hasClass($className)) {
+        $this->reflectionProvider = $reflectionProvider;
+        $this->blacklist = $blacklist;
+    }
+
+    private function validateBlacklist(): void
+    {
+        if ($this->validated) {
+            return;
+        }
+
+        foreach ($this->blacklist as $className) {
+            if (!$this->reflectionProvider->hasClass($className)) {
                 throw new LogicException("Class {$className} used in 'forbidIdenticalClassComparison' does not exist.");
             }
         }
-
-        $this->blacklist = $blacklist;
+        $this->validated = true;
     }
 
     public function getNodeType(): string
@@ -70,6 +83,8 @@ class ForbidIdenticalClassComparisonRule implements Rule
         if (!$node instanceof Identical && !$node instanceof NotIdentical) {
             return [];
         }
+
+        $this->validateBlacklist();
 
         $nodeType = $scope->getType($node);
         $rightType = $scope->getType($node->right);


### PR DESCRIPTION
Avoids warming up the reflection cache during rule instantiation even if the rule is never used in a given analysis run.

This is mostly to take advantage of https://github.com/phpstan/phpstan-src/pull/5577 and avoid Better Reflection cache initialization cost in the main phpstan process.