### PR TITLE
Rule constructor no-reflection used test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "phpstan/phpstan": "^2.1.32"
+        "phpstan/phpstan": "^2.1.33"
     },
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "^10.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59182fbb76ecac9f9372a04b5c6033ed",
+    "content-hash": "85b4a6f342a30fa3a3b22294f3ce1f30",
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.32",
+            "version": "2.1.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e126cad1e30a99b137b8ed75a85a676450ebb227",
-                "reference": "e126cad1e30a99b137b8ed75a85a676450ebb227",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-11T15:18:17+00:00"
+            "time": "2025-12-05T10:24:31+00:00"
         }
     ],
     "packages-dev": [
@@ -3524,11 +3524,11 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},
-    "prefer-stable": false,
-    "prefer-lowest": false,
+    "prefer-stable": true,
+    "prefer-lowest": true,
     "platform": {
         "php": "^7.4 || ^8.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/NoReflectionInRuleConstructorTest.neon
+++ b/tests/NoReflectionInRuleConstructorTest.neon
@@ -1,0 +1,3 @@
+services:
+    betterReflectionSourceLocator:
+        class: ShipMonk\PHPStan\ThrowingSourceLocator

--- a/tests/NoReflectionInRuleConstructorTest.php
+++ b/tests/NoReflectionInRuleConstructorTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan;
+
+use PHPStan\Testing\PHPStanTestCase;
+use function array_merge;
+
+class NoReflectionInRuleConstructorTest extends PHPStanTestCase
+{
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return array_merge(
+            parent::getAdditionalConfigFiles(),
+            [
+                __DIR__ . '/../rules.neon',
+                __DIR__ . '/NoReflectionInRuleConstructorTest.neon',
+            ],
+        );
+    }
+
+    public function test(): void
+    {
+        self::expectNotToPerformAssertions();
+
+        self::getContainer()->getServicesByTag('phpstan.rules.rule');
+    }
+
+}

--- a/tests/ThrowingSourceLocator.php
+++ b/tests/ThrowingSourceLocator.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\PHPStan;
+
+use LogicException;
+use PHPStan\BetterReflection\Identifier\Identifier;
+use PHPStan\BetterReflection\Identifier\IdentifierType;
+use PHPStan\BetterReflection\Reflection\Reflection;
+use PHPStan\BetterReflection\Reflector\Reflector;
+use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
+
+class ThrowingSourceLocator implements SourceLocator
+{
+
+    public function locateIdentifier(
+        Reflector $reflector,
+        Identifier $identifier
+    ): ?Reflection // @phpstan-ignore return.internalInterface
+    {
+        throw new LogicException('Reflection must not be called during rule construction');
+    }
+
+    /**
+     * @return list<Reflection>
+     */
+    public function locateIdentifiersByType(
+        Reflector $reflector,
+        IdentifierType $identifierType
+    ): array // @phpstan-ignore return.internalInterface
+    {
+        throw new LogicException('Reflection must not be called during rule construction');
+    }
+
+}


### PR DESCRIPTION
Regression test for https://github.com/shipmonk-rnd/phpstan-rules/pull/358

The PHPStan patch version bump needed to allow overriding the source locator in tests - enabled by https://github.com/phpstan/phpstan-src/commit/05b80ef86178c078bff640b9d2ac5ec060731d3f#diff-7e21c6960bd32c7be79f843cd11c3d60101f015beac347eb62fb45f038d0e952