### PR TITLE
Drop support for PHP < 8.1

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,7 +34,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ ubuntu-latest, windows-latest ]
-                php-version: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+                php-version: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
         steps:
             -
@@ -47,9 +47,7 @@ jobs:
                     php-version: ${{ matrix.php-version }}
             -
                 name: Update dependencies
-                run: |
-                    composer remove --dev shipmonk/coverage-guard --no-update
-                    composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                run: composer update --no-progress --${{ matrix.dependency-version }} --prefer-dist --no-interaction
             -
                 name: Run tests
                 run: composer check:tests

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "static analysis"
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "phpstan/phpstan": "^2.1.33"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85b4a6f342a30fa3a3b22294f3ce1f30",
+    "content-hash": "b9a53fae0ff903be926fa879020c136e",
     "packages": [
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.33",
+            "version": "2.1.54",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
-                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
                 "shasum": ""
             },
             "require": {
@@ -57,22 +57,22 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T10:24:31+00:00"
+            "time": "2026-04-29T13:31:09+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -155,7 +155,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -280,16 +280,16 @@
         },
         {
             "name": "ergebnis/composer-normalize",
-            "version": "2.48.2",
+            "version": "2.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/composer-normalize.git",
-                "reference": "86dc9731b8320f49e9be9ad6d8e4de9b8b0e9b8b"
+                "reference": "988f83f5e51a42cdd2337e5fcd935432f8dfa33c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/86dc9731b8320f49e9be9ad6d8e4de9b8b0e9b8b",
-                "reference": "86dc9731b8320f49e9be9ad6d8e4de9b8b0e9b8b",
+                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/988f83f5e51a42cdd2337e5fcd935432f8dfa33c",
+                "reference": "988f83f5e51a42cdd2337e5fcd935432f8dfa33c",
                 "shasum": ""
             },
             "require": {
@@ -303,27 +303,27 @@
                 "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "require-dev": {
-                "composer/composer": "^2.8.3",
+                "composer/composer": "^2.9.8",
                 "ergebnis/license": "^2.7.0",
-                "ergebnis/php-cs-fixer-config": "^6.53.0",
-                "ergebnis/phpstan-rules": "^2.11.0",
-                "ergebnis/phpunit-slow-test-detector": "^2.20.0",
+                "ergebnis/php-cs-fixer-config": "^6.62.1",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.18.1",
                 "fakerphp/faker": "^1.24.1",
-                "infection/infection": "~0.26.6",
                 "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^2.1.17",
-                "phpstan/phpstan-deprecation-rules": "^2.0.3",
-                "phpstan/phpstan-phpunit": "^2.0.7",
-                "phpstan/phpstan-strict-rules": "^2.0.6",
-                "phpunit/phpunit": "^9.6.20",
-                "rector/rector": "^2.1.4",
+                "phpstan/phpstan": "^2.1.54",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.11",
+                "phpunit/phpunit": "^9.6.33",
+                "rector/rector": "^2.4.3",
                 "symfony/filesystem": "^5.4.41"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "Ergebnis\\Composer\\Normalize\\NormalizePlugin",
                 "branch-alias": {
-                    "dev-main": "2.49-dev"
+                    "dev-main": "2.52-dev"
                 },
                 "plugin-optional": true,
                 "composer-normalize": {
@@ -360,7 +360,7 @@
                 "security": "https://github.com/ergebnis/composer-normalize/blob/main/.github/SECURITY.md",
                 "source": "https://github.com/ergebnis/composer-normalize"
             },
-            "time": "2025-09-06T11:42:34+00:00"
+            "time": "2026-05-15T15:39:24+00:00"
         },
         {
             "name": "ergebnis/json",
@@ -519,36 +519,38 @@
         },
         {
             "name": "ergebnis/json-pointer",
-            "version": "3.7.1",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/json-pointer.git",
-                "reference": "43bef355184e9542635e35dd2705910a3df4c236"
+                "reference": "b58c3c468a7ff109fdf9a255f17de29ecbe5276c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/json-pointer/zipball/43bef355184e9542635e35dd2705910a3df4c236",
-                "reference": "43bef355184e9542635e35dd2705910a3df4c236",
+                "url": "https://api.github.com/repos/ergebnis/json-pointer/zipball/b58c3c468a7ff109fdf9a255f17de29ecbe5276c",
+                "reference": "b58c3c468a7ff109fdf9a255f17de29ecbe5276c",
                 "shasum": ""
             },
             "require": {
                 "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "require-dev": {
-                "ergebnis/composer-normalize": "^2.43.0",
-                "ergebnis/data-provider": "^3.2.0",
-                "ergebnis/license": "^2.4.0",
-                "ergebnis/php-cs-fixer-config": "^6.32.0",
-                "ergebnis/phpunit-slow-test-detector": "^2.15.0",
-                "fakerphp/faker": "^1.23.1",
+                "ergebnis/composer-normalize": "^2.50.0",
+                "ergebnis/data-provider": "^3.6.0",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.60.2",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.16.0",
+                "fakerphp/faker": "^1.24.1",
                 "infection/infection": "~0.26.6",
                 "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^1.12.10",
-                "phpstan/phpstan-deprecation-rules": "^1.2.1",
-                "phpstan/phpstan-phpunit": "^1.4.0",
-                "phpstan/phpstan-strict-rules": "^1.6.1",
-                "phpunit/phpunit": "^9.6.19",
-                "rector/rector": "^1.2.10"
+                "phpstan/phpstan": "^2.1.46",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^9.6.34",
+                "rector/rector": "^2.4.0"
             },
             "type": "library",
             "extra": {
@@ -588,7 +590,7 @@
                 "security": "https://github.com/ergebnis/json-pointer/blob/main/.github/SECURITY.md",
                 "source": "https://github.com/ergebnis/json-pointer"
             },
-            "time": "2025-09-06T09:28:19+00:00"
+            "time": "2026-04-07T14:52:13+00:00"
         },
         {
             "name": "ergebnis/json-printer",
@@ -744,26 +746,26 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.6.1",
+            "version": "6.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "fd8e5c6b1badb998844ad34ce0abcd71a0aeb396"
+                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/fd8e5c6b1badb998844ad34ce0abcd71a0aeb396",
-                "reference": "fd8e5c6b1badb998844ad34ce0abcd71a0aeb396",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "marc-mabe/php-enum": "^4.0",
+                "marc-mabe/php-enum": "^4.4",
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "3.3.0",
-                "json-schema/json-schema-test-suite": "^23.2",
+                "json-schema/json-schema-test-suite": "dev-main",
                 "marc-mabe/php-enum-phpstan": "^2.0",
                 "phpspec/prophecy": "^1.19",
                 "phpstan/phpstan": "^1.12",
@@ -813,9 +815,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.6.1"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.2"
             },
-            "time": "2025-11-07T18:30:29+00:00"
+            "time": "2026-05-05T05:39:01+00:00"
         },
         {
             "name": "localheinz/diff",
@@ -1007,16 +1009,16 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.3",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "url": "https://api.github.com/repos/nette/schema/zipball/f0ab1a3cda782dbc5da270d28545236aa80c4002",
+                "reference": "f0ab1a3cda782dbc5da270d28545236aa80c4002",
                 "shasum": ""
             },
             "require": {
@@ -1024,8 +1026,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -1066,26 +1070,26 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.3"
+                "source": "https://github.com/nette/schema/tree/v1.3.5"
             },
-            "time": "2025-10-30T22:57:59+00:00"
+            "time": "2026-02-23T03:47:12+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.9",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "505a30ad386daa5211f08a318e47015b501cad30"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/505a30ad386daa5211f08a318e47015b501cad30",
-                "reference": "505a30ad386daa5211f08a318e47015b501cad30",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
-                "php": "8.0 - 8.5"
+                "php": "8.2 - 8.5"
             },
             "conflict": {
                 "nette/finder": "<3",
@@ -1093,8 +1097,10 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
@@ -1108,7 +1114,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -1155,9 +1161,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.9"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2025-10-31T00:45:47+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -1337,16 +1343,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -1378,27 +1384,27 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2025-08-30T15:50:23+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
-                "reference": "468e02c9176891cc901143da118f09dc9505fc2f"
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/468e02c9176891cc901143da118f09dc9505fc2f",
-                "reference": "468e02c9176891cc901143da118f09dc9505fc2f",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/6b5571001a7f04fa0422254c30a0017ec2f2cacc",
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.1.15"
+                "phpstan/phpstan": "^2.1.39"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -1423,24 +1429,27 @@
                 "MIT"
             ],
             "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.3"
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.4"
             },
-            "time": "2025-05-14T10:56:57+00:00"
+            "time": "2026-02-09T13:21:14+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "2.0.8",
+            "version": "2.0.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "2fe9fbeceaf76dd1ebaa7bbbb25e2fb5e59db2fe"
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/2fe9fbeceaf76dd1ebaa7bbbb25e2fb5e59db2fe",
-                "reference": "2fe9fbeceaf76dd1ebaa7bbbb25e2fb5e59db2fe",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
                 "shasum": ""
             },
             "require": {
@@ -1476,29 +1485,32 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.8"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.16"
             },
-            "time": "2025-11-11T07:55:22+00:00"
+            "time": "2026-02-14T09:05:21+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.7",
+            "version": "2.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538"
+                "reference": "9b000a578b85b32945b358b172c7b20e91189024"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/d6211c46213d4181054b3d77b10a5c5cb0d59538",
-                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/9b000a578b85b32945b358b172c7b20e91189024",
+                "reference": "9b000a578b85b32945b358b172c7b20e91189024",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.1.29"
+                "phpstan/phpstan": "^2.1.39"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -1524,11 +1536,14 @@
                 "MIT"
             ],
             "description": "Extra strict and opinionated rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.7"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.11"
             },
-            "time": "2025-09-26T11:19:08+00:00"
+            "time": "2026-05-02T06:54:10+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2973,21 +2988,21 @@
         },
         {
             "name": "shipmonk/coding-standard",
-            "version": "0.2.0",
+            "version": "0.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "eabe46b1cf541e24692fb6f4700b7b95da3676ec"
+                "reference": "ca7fa071f5943d87f67e791fe36a691a36d10275"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/eabe46b1cf541e24692fb6f4700b7b95da3676ec",
-                "reference": "eabe46b1cf541e24692fb6f4700b7b95da3676ec",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/ca7fa071f5943d87f67e791fe36a691a36d10275",
+                "reference": "ca7fa071f5943d87f67e791fe36a691a36d10275",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "slevomat/coding-standard": "^8.25.0"
+                "slevomat/coding-standard": "^8.28.0"
             },
             "require-dev": {
                 "editorconfig-checker/editorconfig-checker": "^10.6",
@@ -3015,9 +3030,9 @@
             "description": "PHP Coding Standard used in ShipMonk",
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
-                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.2.0"
+                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.2.4"
             },
-            "time": "2025-11-25T11:07:36+00:00"
+            "time": "2026-03-16T16:23:10+00:00"
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
@@ -3087,16 +3102,16 @@
         },
         {
             "name": "shipmonk/coverage-guard",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coverage-guard.git",
-                "reference": "2ce122d97467e8f02933f54bf51ee7b3cc8a8d83"
+                "reference": "8ca675c13740c0d83fe32af979cd0afc934216de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coverage-guard/zipball/2ce122d97467e8f02933f54bf51ee7b3cc8a8d83",
-                "reference": "2ce122d97467e8f02933f54bf51ee7b3cc8a8d83",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coverage-guard/zipball/8ca675c13740c0d83fe32af979cd0afc934216de",
+                "reference": "8ca675c13740c0d83fe32af979cd0afc934216de",
                 "shasum": ""
             },
             "require": {
@@ -3141,9 +3156,9 @@
             ],
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coverage-guard/issues",
-                "source": "https://github.com/shipmonk-rnd/coverage-guard/tree/1.0.0"
+                "source": "https://github.com/shipmonk-rnd/coverage-guard/tree/1.0.2"
             },
-            "time": "2025-12-08T08:45:32+00:00"
+            "time": "2026-01-02T13:56:38+00:00"
         },
         {
             "name": "shipmonk/dead-code-detector",
@@ -3274,16 +3289,16 @@
         },
         {
             "name": "shipmonk/phpstan-dev",
-            "version": "0.1.5",
+            "version": "0.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/phpstan-dev.git",
-                "reference": "bdbf5ee0782d8989bb8d23299bcf9337c7ce2830"
+                "reference": "a8c16883ac3762783cac0496dc069024fa9e77aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/phpstan-dev/zipball/bdbf5ee0782d8989bb8d23299bcf9337c7ce2830",
-                "reference": "bdbf5ee0782d8989bb8d23299bcf9337c7ce2830",
+                "url": "https://api.github.com/repos/shipmonk-rnd/phpstan-dev/zipball/a8c16883ac3762783cac0496dc069024fa9e77aa",
+                "reference": "a8c16883ac3762783cac0496dc069024fa9e77aa",
                 "shasum": ""
             },
             "require": {
@@ -3322,38 +3337,38 @@
             ],
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/phpstan-dev/issues",
-                "source": "https://github.com/shipmonk-rnd/phpstan-dev/tree/0.1.5"
+                "source": "https://github.com/shipmonk-rnd/phpstan-dev/tree/0.1.6"
             },
-            "time": "2026-01-22T18:22:28+00:00"
+            "time": "2026-01-29T15:37:11+00:00"
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.25.1",
+            "version": "8.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "4caa5ec5a30b84b2305e80159c710d437f40cc40"
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/4caa5ec5a30b84b2305e80159c710d437f40cc40",
-                "reference": "4caa5ec5a30b84b2305e80159c710d437f40cc40",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.2.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.1",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpdoc-parser": "^2.3.0",
+                "phpstan/phpdoc-parser": "^2.3.2",
                 "squizlabs/php_codesniffer": "^4.0.1"
             },
             "require-dev": {
-                "phing/phing": "3.0.1|3.1.0",
+                "phing/phing": "3.0.1|3.1.2",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.32",
-                "phpstan/phpstan-deprecation-rules": "2.0.3",
-                "phpstan/phpstan-phpunit": "2.0.8",
-                "phpstan/phpstan-strict-rules": "2.0.7",
-                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.36|12.4.4"
+                "phpstan/phpstan": "2.1.54",
+                "phpstan/phpstan-deprecation-rules": "2.0.4",
+                "phpstan/phpstan-phpunit": "2.0.16",
+                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.55|12.5.24"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -3377,7 +3392,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.25.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.29.0"
             },
             "funding": [
                 {
@@ -3389,7 +3404,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-25T18:01:43+00:00"
+            "time": "2026-05-07T05:48:08+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -3524,11 +3539,11 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},
-    "prefer-stable": true,
-    "prefer-lowest": true,
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
-        "php": "^7.4 || ^8.0"
+        "php": "^8.1"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -11,16 +11,10 @@
 
     <exclude-pattern>tests/*/data/*</exclude-pattern>
 
-    <config name="php_version" value="70400"/>
+    <config name="php_version" value="80100"/>
     <config name="installed_paths" value="vendor/slevomat/coding-standard,vendor/shipmonk/coding-standard"/>
 
     <rule ref="ShipMonkCodingStandard">
         <exclude name="SlevomatCodingStandard.Commenting.ForbiddenAnnotations.AnnotationForbidden"/><!-- It removes @dataProvider, but PHPUnit 9 does not yet have #[DataProvider] -->
-    </rule>
-
-    <rule ref="SlevomatCodingStandard.Functions.DisallowTrailingCommaInDeclaration">
-        <properties>
-            <property name="onlySingleLine" value="false"/>
-        </properties>
     </rule>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,7 +10,7 @@ includes:
 
 parameters:
     phpVersion:
-        min: 70400
+        min: 80100
         max: 80599
     internalErrorsCountLimit: 1
     paths:
@@ -45,20 +45,8 @@ parameters:
                 PHPStan\Rules\Rule: Rule
                 PhpParser\NodeVisitor: Visitor
                 ShipMonk\PHPStan\RuleTestCase: RuleTest
-        enforceClosureParamNativeTypehint:
-            enabled: false # we support even PHP 7.4, some typehints cannot be used
 
     ignoreErrors:
-        -
-            message: "#Class BackedEnum not found\\.#"
-            path: src/Rule/BackedEnumGenericsRule.php
-            reportUnmatched: false # fails only for PHP < 8 https://github.com/phpstan/phpstan/issues/6290
-
-        -
-            message: "#Call to method PHPStan\\\\Reflection\\\\ClassReflection::isEnum\\(\\) will always evaluate to false\\.#"
-            path: src/Rule/ForbidProtectedEnumMethodRule.php
-            reportUnmatched: false # fails only for PHP < 8 https://github.com/phpstan/phpstan-src/pull/3925/files#diff-df58b1c8117cfa9b77453fb2cc8fdeeb0803ad0acfd2dec85a441a8fa5a53c06R24
-
         -
             message: "#but it's missing from the PHPDoc @throws tag\\.$#" # allow uncatched exceptions in tests
             path: tests/*

--- a/src/Rule/AllowComparingOnlyComparableTypesRule.php
+++ b/src/Rule/AllowComparingOnlyComparableTypesRule.php
@@ -41,7 +41,7 @@ class AllowComparingOnlyComparableTypesRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (
@@ -109,7 +109,7 @@ class AllowComparingOnlyComparableTypesRule implements Rule
 
     private function isComparableTogether(
         Type $leftType,
-        Type $rightType
+        Type $rightType,
     ): bool
     {
         $intType = new IntegerType();
@@ -150,7 +150,7 @@ class AllowComparingOnlyComparableTypesRule implements Rule
                     }
 
                     for ($i = 0; $i < count($leftValueTypes); $i++) {
-                        if (!$this->isComparableTogether($leftValueTypes[$i], $rightValueTypes[$i])) { // @phpstan-ignore offsetAccess.notFound
+                        if (!$this->isComparableTogether($leftValueTypes[$i], $rightValueTypes[$i])) { // @phpstan-ignore offsetAccess.notFound, offsetAccess.notFound
                             return false;
                         }
                     }
@@ -168,7 +168,7 @@ class AllowComparingOnlyComparableTypesRule implements Rule
      */
     private function containsOnlyTypes(
         Type $checkedType,
-        array $allowedTypes
+        array $allowedTypes,
     ): bool
     {
         $allowedType = TypeCombinator::union(...$allowedTypes);

--- a/src/Rule/BackedEnumGenericsRule.php
+++ b/src/Rule/BackedEnumGenericsRule.php
@@ -29,7 +29,7 @@ class BackedEnumGenericsRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $classReflection = $node->getClassReflection();
@@ -60,7 +60,7 @@ class BackedEnumGenericsRule implements Rule
 
     private function hasGenericsTag(
         ClassReflection $classReflection,
-        string $expectedTag
+        string $expectedTag,
     ): bool
     {
         if ($classReflection->isBackedEnum()) {

--- a/src/Rule/ClassSuffixNamingRule.php
+++ b/src/Rule/ClassSuffixNamingRule.php
@@ -10,8 +10,7 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function strlen;
-use function substr_compare;
+use function str_ends_with;
 
 /**
  * @implements Rule<InClassNode>
@@ -19,25 +18,16 @@ use function substr_compare;
 class ClassSuffixNamingRule implements Rule
 {
 
-    private ReflectionProvider $reflectionProvider;
-
-    /**
-     * @var array<class-string, string>
-     */
-    private array $superclassToSuffixMapping;
-
     private bool $validated = false;
 
     /**
      * @param array<class-string, string> $superclassToSuffixMapping
      */
     public function __construct(
-        ReflectionProvider $reflectionProvider,
-        array $superclassToSuffixMapping = []
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly array $superclassToSuffixMapping = [],
     )
     {
-        $this->reflectionProvider = $reflectionProvider;
-        $this->superclassToSuffixMapping = $superclassToSuffixMapping;
     }
 
     private function validateSuperclassToSuffixMapping(): void
@@ -65,7 +55,7 @@ class ClassSuffixNamingRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $this->validateSuperclassToSuffixMapping();
@@ -92,7 +82,7 @@ class ClassSuffixNamingRule implements Rule
 
             $className = $classReflection->getName();
 
-            if (substr_compare($className, $suffix, -strlen($suffix)) !== 0) {
+            if (!str_ends_with($className, $suffix)) {
                 $error = RuleErrorBuilder::message("Class name $className should end with $suffix suffix")
                     ->identifier('shipmonk.invalidClassSuffix')
                     ->build();

--- a/src/Rule/EnforceClosureParamNativeTypehintRule.php
+++ b/src/Rule/EnforceClosureParamNativeTypehintRule.php
@@ -20,17 +20,11 @@ use function is_string;
 class EnforceClosureParamNativeTypehintRule implements Rule
 {
 
-    private PhpVersion $phpVersion;
-
-    private bool $allowMissingTypeWhenInferred;
-
     public function __construct(
-        PhpVersion $phpVersion,
-        bool $allowMissingTypeWhenInferred
+        private readonly PhpVersion $phpVersion,
+        private readonly bool $allowMissingTypeWhenInferred,
     )
     {
-        $this->phpVersion = $phpVersion;
-        $this->allowMissingTypeWhenInferred = $allowMissingTypeWhenInferred;
     }
 
     public function getNodeType(): string
@@ -43,7 +37,7 @@ class EnforceClosureParamNativeTypehintRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$node instanceof InClosureNode && !$node instanceof InArrowFunctionNode) {

--- a/src/Rule/EnforceEnumMatchRule.php
+++ b/src/Rule/EnforceEnumMatchRule.php
@@ -34,7 +34,7 @@ class EnforceEnumMatchRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$node instanceof Identical && !$node instanceof NotIdentical) {

--- a/src/Rule/EnforceIteratorToArrayPreserveKeysRule.php
+++ b/src/Rule/EnforceIteratorToArrayPreserveKeysRule.php
@@ -29,7 +29,7 @@ class EnforceIteratorToArrayPreserveKeysRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$node->name instanceof Name) {

--- a/src/Rule/EnforceListReturnRule.php
+++ b/src/Rule/EnforceListReturnRule.php
@@ -30,7 +30,7 @@ class EnforceListReturnRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $methodReflection = $scope->getFunction();

--- a/src/Rule/EnforceNativeReturnTypehintRule.php
+++ b/src/Rule/EnforceNativeReturnTypehintRule.php
@@ -42,21 +42,12 @@ use function sprintf;
 class EnforceNativeReturnTypehintRule implements Rule
 {
 
-    private FileTypeMapper $fileTypeMapper;
-
-    private PhpVersion $phpVersion;
-
-    private bool $treatPhpDocTypesAsCertain;
-
     public function __construct(
-        FileTypeMapper $fileTypeMapper,
-        PhpVersion $phpVersion,
-        bool $treatPhpDocTypesAsCertain
+        private readonly FileTypeMapper $fileTypeMapper,
+        private readonly PhpVersion $phpVersion,
+        private readonly bool $treatPhpDocTypesAsCertain,
     )
     {
-        $this->fileTypeMapper = $fileTypeMapper;
-        $this->phpVersion = $phpVersion;
-        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
     }
 
     public function getNodeType(): string
@@ -70,7 +61,7 @@ class EnforceNativeReturnTypehintRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($this->treatPhpDocTypesAsCertain === false) {
@@ -114,7 +105,7 @@ class EnforceNativeReturnTypehintRule implements Rule
         Scope $scope,
         bool $typeFromPhpDoc,
         bool $alwaysThrowsException,
-        bool $topLevel
+        bool $topLevel,
     ): ?string
     {
         if ($type instanceof MixedType || $this->isUnionTypeWithMixed($type)) {
@@ -212,7 +203,7 @@ class EnforceNativeReturnTypehintRule implements Rule
 
     private function getPhpDocReturnType(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): ?Type
     {
         $docComment = $node->getDocComment();
@@ -251,7 +242,7 @@ class EnforceNativeReturnTypehintRule implements Rule
         Type $type,
         Scope $scope,
         bool $typeFromPhpDoc,
-        bool $alwaysThrowsException
+        bool $alwaysThrowsException,
     ): ?string
     {
         if (!$type instanceof UnionType) {
@@ -295,7 +286,7 @@ class EnforceNativeReturnTypehintRule implements Rule
         Type $type,
         Scope $scope,
         bool $typeFromPhpDoc,
-        bool $alwaysThrowsException
+        bool $alwaysThrowsException,
     ): ?string
     {
         if (!$type instanceof IntersectionType) { // @phpstan-ignore phpstanApi.instanceofType

--- a/src/Rule/EnforceReadonlyPublicPropertyRule.php
+++ b/src/Rule/EnforceReadonlyPublicPropertyRule.php
@@ -16,17 +16,11 @@ use PHPStan\Rules\RuleErrorBuilder;
 class EnforceReadonlyPublicPropertyRule implements Rule
 {
 
-    private bool $excludePropertyWithDefaultValue;
-
-    private PhpVersion $phpVersion;
-
     public function __construct(
-        bool $excludePropertyWithDefaultValue,
-        PhpVersion $phpVersion
+        private readonly bool $excludePropertyWithDefaultValue,
+        private readonly PhpVersion $phpVersion,
     )
     {
-        $this->excludePropertyWithDefaultValue = $excludePropertyWithDefaultValue;
-        $this->phpVersion = $phpVersion;
     }
 
     public function getNodeType(): string
@@ -40,7 +34,7 @@ class EnforceReadonlyPublicPropertyRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$this->phpVersion->supportsReadOnlyProperties()) {

--- a/src/Rule/ForbidArithmeticOperationOnNonNumberRule.php
+++ b/src/Rule/ForbidArithmeticOperationOnNonNumberRule.php
@@ -31,11 +31,8 @@ use function sprintf;
 class ForbidArithmeticOperationOnNonNumberRule implements Rule
 {
 
-    private bool $allowNumericString;
-
-    public function __construct(bool $allowNumericString)
+    public function __construct(private readonly bool $allowNumericString)
     {
-        $this->allowNumericString = $allowNumericString;
     }
 
     public function getNodeType(): string
@@ -48,7 +45,7 @@ class ForbidArithmeticOperationOnNonNumberRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (
@@ -78,7 +75,7 @@ class ForbidArithmeticOperationOnNonNumberRule implements Rule
     private function processUnary(
         Expr $expr,
         Scope $scope,
-        string $operator
+        string $operator,
     ): array
     {
         $exprType = $scope->getType($expr);
@@ -105,7 +102,7 @@ class ForbidArithmeticOperationOnNonNumberRule implements Rule
         Expr $left,
         Expr $right,
         Scope $scope,
-        string $operator
+        string $operator,
     ): array
     {
         $leftType = $scope->getType($left);
@@ -154,7 +151,7 @@ class ForbidArithmeticOperationOnNonNumberRule implements Rule
         string $operator,
         string $type,
         Type $leftType,
-        Type $rightType
+        Type $rightType,
     ): array
     {
         $errorMessage = sprintf(

--- a/src/Rule/ForbidCastRule.php
+++ b/src/Rule/ForbidCastRule.php
@@ -17,7 +17,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function get_class;
 use function in_array;
 
 /**
@@ -29,16 +28,10 @@ class ForbidCastRule implements Rule
     private const DEFAULT_BLACKLIST = ['(array)', '(object)', '(unset)'];
 
     /**
-     * @var string[]
-     */
-    private array $blacklist;
-
-    /**
      * @param string[] $blacklist
      */
-    public function __construct(array $blacklist = self::DEFAULT_BLACKLIST)
+    public function __construct(private readonly array $blacklist = self::DEFAULT_BLACKLIST)
     {
-        $this->blacklist = $blacklist;
     }
 
     public function getNodeType(): string
@@ -52,7 +45,7 @@ class ForbidCastRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $castString = $this->getCastString($node);
@@ -101,7 +94,7 @@ class ForbidCastRule implements Rule
             return '(void)';
         }
 
-        throw new LogicException('Unexpected Cast child: ' . get_class($node));
+        throw new LogicException('Unexpected Cast child: ' . $node::class);
     }
 
 }

--- a/src/Rule/ForbidCheckedExceptionInCallableRule.php
+++ b/src/Rule/ForbidCheckedExceptionInCallableRule.php
@@ -47,19 +47,13 @@ use function explode;
 use function in_array;
 use function is_int;
 use function spl_object_hash;
-use function strpos;
+use function str_contains;
 
 /**
  * @implements Rule<Node>
  */
 class ForbidCheckedExceptionInCallableRule implements Rule
 {
-
-    private NodeScopeResolver $nodeScopeResolver;
-
-    private ReflectionProvider $reflectionProvider;
-
-    private DefaultExceptionTypeResolver $exceptionTypeResolver;
 
     /**
      * @var array<string, bool> spl_hash => true
@@ -70,11 +64,6 @@ class ForbidCheckedExceptionInCallableRule implements Rule
      * @var array<string, string> spl_hash => methodName
      */
     private array $callablesInArguments = [];
-
-    /**
-     * @var array<string, int|list<int>>
-     */
-    private array $rawAllowedCheckedExceptionCallables;
 
     /**
      * class::method => callable argument index
@@ -98,16 +87,12 @@ class ForbidCheckedExceptionInCallableRule implements Rule
      * @param array<string, int|list<int>> $allowedCheckedExceptionCallables
      */
     public function __construct(
-        NodeScopeResolver $nodeScopeResolver,
-        ReflectionProvider $reflectionProvider,
-        DefaultExceptionTypeResolver $exceptionTypeResolver,
-        array $allowedCheckedExceptionCallables
+        private readonly NodeScopeResolver $nodeScopeResolver,
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly DefaultExceptionTypeResolver $exceptionTypeResolver,
+        private readonly array $allowedCheckedExceptionCallables,
     )
     {
-        $this->rawAllowedCheckedExceptionCallables = $allowedCheckedExceptionCallables;
-        $this->exceptionTypeResolver = $exceptionTypeResolver;
-        $this->reflectionProvider = $reflectionProvider;
-        $this->nodeScopeResolver = $nodeScopeResolver;
     }
 
     /**
@@ -116,12 +101,10 @@ class ForbidCheckedExceptionInCallableRule implements Rule
     private function getCallablesAllowingCheckedExceptions(): array
     {
         if ($this->callablesAllowingCheckedExceptions === null) {
-            $this->checkClassExistence($this->reflectionProvider, $this->rawAllowedCheckedExceptionCallables);
+            $this->checkClassExistence($this->reflectionProvider, $this->allowedCheckedExceptionCallables);
             $this->callablesAllowingCheckedExceptions = array_map(
-                function ($argumentIndexes): array {
-                    return $this->normalizeArgumentIndexes($argumentIndexes);
-                },
-                $this->rawAllowedCheckedExceptionCallables,
+                $this->normalizeArgumentIndexes(...),
+                $this->allowedCheckedExceptionCallables,
             );
         }
 
@@ -138,7 +121,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $errors = [];
@@ -183,7 +166,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
      */
     public function processFirstClassCallable(
         CallLike $callNode,
-        Scope $scope
+        Scope $scope,
     ): Generator
     {
         if (!$callNode->isFirstClassCallable()) {
@@ -222,7 +205,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
      * @return Generator<IdentifierRuleError>
      */
     public function processClosure(
-        ClosureReturnStatementsNode $node
+        ClosureReturnStatementsNode $node,
     ): Generator
     {
         $nodeHash = spl_object_hash($node->getClosureExpr());
@@ -255,7 +238,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
      */
     public function processArrowFunction(
         ArrowFunction $node,
-        Scope $scope
+        Scope $scope,
     ): Generator
     {
         if (!$scope instanceof MutatingScope) {
@@ -304,7 +287,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
         Type $callerType,
         string $methodName,
         int $line,
-        string $nodeHash
+        string $nodeHash,
     ): Generator
     {
         $methodReflection = $scope->getMethodReflection($callerType, $methodName);
@@ -321,7 +304,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
         ?Type $throwType,
         Scope $scope,
         int $line,
-        string $nodeHash
+        string $nodeHash,
     ): Generator
     {
         if ($throwType === null) {
@@ -355,11 +338,11 @@ class ForbidCheckedExceptionInCallableRule implements Rule
      */
     private function checkClassExistence(
         ReflectionProvider $reflectionProvider,
-        array $callables
+        array $callables,
     ): void
     {
         foreach ($callables as $call => $args) {
-            if (strpos($call, '::') === false) {
+            if (!str_contains($call, '::')) {
                 continue;
             }
 
@@ -378,7 +361,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
      */
     private function isImmediatelyInvokedCallable(
         object $reflection,
-        ?ParameterReflection $parameter
+        ?ParameterReflection $parameter,
     ): bool
     {
         if ($parameter instanceof ExtendedParameterReflection) {
@@ -397,12 +380,12 @@ class ForbidCheckedExceptionInCallableRule implements Rule
     private function isAllowedCheckedExceptionCallable(
         ?Type $caller,
         string $calledMethodName,
-        int $argumentIndex
+        int $argumentIndex,
     ): bool
     {
         if ($caller === null) {
             foreach ($this->getCallablesAllowingCheckedExceptions() as $immediateFunction => $indexes) {
-                if (strpos($immediateFunction, '::') !== false) {
+                if (str_contains($immediateFunction, '::')) {
                     continue;
                 }
 
@@ -419,7 +402,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
 
         foreach ($caller->getObjectClassReflections() as $callerReflection) {
             foreach ($this->getCallablesAllowingCheckedExceptions() as $immediateCallerAndMethod => $indexes) {
-                if (strpos($immediateCallerAndMethod, '::') === false) {
+                if (!str_contains($immediateCallerAndMethod, '::')) {
                     continue;
                 }
 
@@ -440,7 +423,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
 
     private function whitelistAllowedCallables(
         CallLike $node,
-        Scope $scope
+        Scope $scope,
     ): void
     {
         if ($node instanceof MethodCall && $node->name instanceof Identifier) {
@@ -524,7 +507,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
     private function getParameterIndex(
         Arg $arg,
         int $argumentIndex,
-        array $parameters
+        array $parameters,
     ): ?int
     {
         if ($arg->name === null) {
@@ -555,7 +538,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
         string $where,
         Scope $scope,
         int $line,
-        ?string $usedAsArgumentOfMethodName
+        ?string $usedAsArgumentOfMethodName,
     ): IdentifierRuleError
     {
         $file = $scope->getFile();
@@ -575,7 +558,7 @@ class ForbidCheckedExceptionInCallableRule implements Rule
 
     private function getFunctionReflection(
         Name $functionName,
-        Scope $scope
+        Scope $scope,
     ): ?FunctionReflection
     {
         return $this->reflectionProvider->hasFunction($functionName, $scope)

--- a/src/Rule/ForbidCheckedExceptionInYieldingMethodRule.php
+++ b/src/Rule/ForbidCheckedExceptionInYieldingMethodRule.php
@@ -19,11 +19,8 @@ use PHPStan\Rules\RuleErrorBuilder;
 class ForbidCheckedExceptionInYieldingMethodRule implements Rule
 {
 
-    private ExceptionTypeResolver $exceptionTypeResolver;
-
-    public function __construct(ExceptionTypeResolver $exceptionTypeResolver)
+    public function __construct(private readonly ExceptionTypeResolver $exceptionTypeResolver)
     {
-        $this->exceptionTypeResolver = $exceptionTypeResolver;
     }
 
     public function getNodeType(): string
@@ -37,7 +34,7 @@ class ForbidCheckedExceptionInYieldingMethodRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$node->getStatementResult()->hasYield()) {

--- a/src/Rule/ForbidCustomFunctionsRule.php
+++ b/src/Rule/ForbidCustomFunctionsRule.php
@@ -62,7 +62,7 @@ class ForbidCustomFunctionsRule implements Rule
      */
     public function __construct(
         array $forbiddenFunctions,
-        ReflectionProvider $reflectionProvider
+        ReflectionProvider $reflectionProvider,
     )
     {
         $this->reflectionProvider = $reflectionProvider;
@@ -115,7 +115,7 @@ class ForbidCustomFunctionsRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($this->isFirstClassCallableNode($node)) {
@@ -163,7 +163,7 @@ class ForbidCustomFunctionsRule implements Rule
      */
     private function validateFunctionCall(
         FuncCall $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $functionNames = $this->getFunctionNames($node->name, $scope);
@@ -186,7 +186,7 @@ class ForbidCustomFunctionsRule implements Rule
      */
     private function validateCallOverExpr(
         string $methodName,
-        Type $caller
+        Type $caller,
     ): array
     {
         $classNames = $caller->getObjectTypeOrClassStringObjectType()->getObjectClassNames();
@@ -207,7 +207,7 @@ class ForbidCustomFunctionsRule implements Rule
      */
     private function validateMethod(
         string $methodName,
-        string $className
+        string $className,
     ): array
     {
         if (!$this->reflectionProvider->hasClass($className)) {
@@ -260,7 +260,7 @@ class ForbidCustomFunctionsRule implements Rule
      */
     private function getFunctionNames(
         Node $name,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($name instanceof Name) {
@@ -282,7 +282,7 @@ class ForbidCustomFunctionsRule implements Rule
      */
     private function getMethodNames(
         Node $name,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($name instanceof Name) {
@@ -306,7 +306,7 @@ class ForbidCustomFunctionsRule implements Rule
      */
     private function validateCallable(
         Expr $callable,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $callableType = $scope->getType($callable);
@@ -354,7 +354,7 @@ class ForbidCustomFunctionsRule implements Rule
         Type $caller,
         string $methodName,
         CallLike $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($node->isFirstClassCallable()) {
@@ -389,7 +389,7 @@ class ForbidCustomFunctionsRule implements Rule
     private function validateCallableArguments(
         array $reorderedArgs,
         ParametersAcceptor $parametersAcceptor,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $errors = [];
@@ -412,7 +412,7 @@ class ForbidCustomFunctionsRule implements Rule
     private function validateFunctionArguments(
         string $functionName,
         FuncCall $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($node->isFirstClassCallable()) {
@@ -440,7 +440,7 @@ class ForbidCustomFunctionsRule implements Rule
     private function getMethodReflection(
         string $className,
         string $methodName,
-        Scope $scope
+        Scope $scope,
     ): ?ExtendedMethodReflection
     {
         if (!$this->reflectionProvider->hasClass($className)) {
@@ -458,7 +458,7 @@ class ForbidCustomFunctionsRule implements Rule
 
     private function getFunctionReflection(
         Name $functionName,
-        Scope $scope
+        Scope $scope,
     ): ?FunctionReflection
     {
         return $this->reflectionProvider->hasFunction($functionName, $scope)
@@ -468,7 +468,7 @@ class ForbidCustomFunctionsRule implements Rule
 
     private function getNewCaller(
         New_ $new,
-        Scope $scope
+        Scope $scope,
     ): Type
     {
         if ($new->class instanceof Class_) {

--- a/src/Rule/ForbidEnumInFunctionArgumentsRule.php
+++ b/src/Rule/ForbidEnumInFunctionArgumentsRule.php
@@ -40,11 +40,8 @@ class ForbidEnumInFunctionArgumentsRule implements Rule
         'array_sum' => [0, self::REASON_UNPREDICTABLE_RESULT],
     ];
 
-    private ReflectionProvider $reflectionProvider;
-
-    public function __construct(ReflectionProvider $reflectionProvider)
+    public function __construct(private readonly ReflectionProvider $reflectionProvider)
     {
-        $this->reflectionProvider = $reflectionProvider;
     }
 
     public function getNodeType(): string
@@ -58,7 +55,7 @@ class ForbidEnumInFunctionArgumentsRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$node->name instanceof Name) {
@@ -114,7 +111,7 @@ class ForbidEnumInFunctionArgumentsRule implements Rule
 
     private function matchesPosition(
         int $position,
-        int $forbiddenArgumentPosition
+        int $forbiddenArgumentPosition,
     ): bool
     {
         return $position === $forbiddenArgumentPosition;
@@ -141,7 +138,7 @@ class ForbidEnumInFunctionArgumentsRule implements Rule
 
     private function getFunctionReflection(
         Name $functionName,
-        Scope $scope
+        Scope $scope,
     ): ?FunctionReflection
     {
         return $this->reflectionProvider->hasFunction($functionName, $scope)

--- a/src/Rule/ForbidFetchOnMixedRule.php
+++ b/src/Rule/ForbidFetchOnMixedRule.php
@@ -16,7 +16,6 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeUtils;
-use function get_class;
 use function sprintf;
 
 /**
@@ -25,17 +24,11 @@ use function sprintf;
 class ForbidFetchOnMixedRule implements Rule
 {
 
-    private Printer $printer;
-
-    private bool $checkExplicitMixed;
-
     public function __construct(
-        Printer $printer,
-        bool $checkExplicitMixed
+        private readonly Printer $printer,
+        private readonly bool $checkExplicitMixed,
     )
     {
-        $this->printer = $printer;
-        $this->checkExplicitMixed = $checkExplicitMixed;
     }
 
     public function getNodeType(): string
@@ -48,7 +41,7 @@ class ForbidFetchOnMixedRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($this->checkExplicitMixed) {
@@ -68,7 +61,7 @@ class ForbidFetchOnMixedRule implements Rule
      */
     private function processFetch(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $caller = $node instanceof PropertyFetch
@@ -114,17 +107,11 @@ class ForbidFetchOnMixedRule implements Rule
      */
     private function getFetchToken(Node $node): string
     {
-        switch (get_class($node)) {
-            case ClassConstFetch::class:
-            case StaticPropertyFetch::class:
-                return '::';
-
-            case PropertyFetch::class:
-                return '->';
-
-            default:
-                throw new LogicException('Unexpected node given: ' . get_class($node));
-        }
+        return match ($node::class) {
+            ClassConstFetch::class, StaticPropertyFetch::class => '::',
+            PropertyFetch::class => '->',
+            default => throw new LogicException('Unexpected node given: ' . $node::class),
+        };
     }
 
     /**
@@ -134,7 +121,7 @@ class ForbidFetchOnMixedRule implements Rule
      */
     private function isObjectClassFetch(
         Type $callerType,
-        Node $node
+        Node $node,
     ): bool
     {
         $isObjectWithoutClassName = $callerType->isObject()->yes() && $callerType->getObjectClassNames() === [];

--- a/src/Rule/ForbidIdenticalClassComparisonRule.php
+++ b/src/Rule/ForbidIdenticalClassComparisonRule.php
@@ -27,25 +27,16 @@ class ForbidIdenticalClassComparisonRule implements Rule
 
     private const DEFAULT_BLACKLIST = [DateTimeInterface::class];
 
-    private ReflectionProvider $reflectionProvider;
-
-    /**
-     * @var array<int, class-string<object>>
-     */
-    private array $blacklist;
-
     private bool $validated = false;
 
     /**
      * @param array<int, class-string<object>> $blacklist
      */
     public function __construct(
-        ReflectionProvider $reflectionProvider,
-        array $blacklist = self::DEFAULT_BLACKLIST
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly array $blacklist = self::DEFAULT_BLACKLIST,
     )
     {
-        $this->reflectionProvider = $reflectionProvider;
-        $this->blacklist = $blacklist;
     }
 
     private function validateBlacklist(): void
@@ -73,7 +64,7 @@ class ForbidIdenticalClassComparisonRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (count($this->blacklist) === 0) {
@@ -115,7 +106,7 @@ class ForbidIdenticalClassComparisonRule implements Rule
 
     private function containsClass(
         Type $type,
-        string $className
+        string $className,
     ): bool
     {
         $benevolentType = TypeUtils::toBenevolentUnion($type);

--- a/src/Rule/ForbidIncrementDecrementOnNonIntegerRule.php
+++ b/src/Rule/ForbidIncrementDecrementOnNonIntegerRule.php
@@ -13,7 +13,6 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\VerbosityLevel;
-use function get_class;
 use function sprintf;
 
 /**
@@ -32,7 +31,7 @@ class ForbidIncrementDecrementOnNonIntegerRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (
@@ -53,7 +52,7 @@ class ForbidIncrementDecrementOnNonIntegerRule implements Rule
      */
     private function process(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $exprType = $scope->getType($node->var);
@@ -78,18 +77,11 @@ class ForbidIncrementDecrementOnNonIntegerRule implements Rule
      */
     private function getIncDecSymbol(Node $node): string
     {
-        switch (get_class($node)) {
-            case PostInc::class:
-            case PreInc::class:
-                return '++';
-
-            case PostDec::class:
-            case PreDec::class:
-                return '--';
-
-            default:
-                throw new LogicException('Unexpected node given: ' . get_class($node));
-        }
+        return match ($node::class) {
+            PostInc::class, PreInc::class => '++',
+            PostDec::class, PreDec::class => '--',
+            default => throw new LogicException('Unexpected node given: ' . $node::class),
+        };
     }
 
 }

--- a/src/Rule/ForbidMatchDefaultArmForEnumsRule.php
+++ b/src/Rule/ForbidMatchDefaultArmForEnumsRule.php
@@ -27,7 +27,7 @@ class ForbidMatchDefaultArmForEnumsRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $matchCondition = $node->getCondition();

--- a/src/Rule/ForbidMethodCallOnMixedRule.php
+++ b/src/Rule/ForbidMethodCallOnMixedRule.php
@@ -15,7 +15,6 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\TypeUtils;
-use function get_class;
 use function sprintf;
 
 /**
@@ -24,17 +23,11 @@ use function sprintf;
 class ForbidMethodCallOnMixedRule implements Rule
 {
 
-    private Printer $printer;
-
-    private bool $checkExplicitMixed;
-
     public function __construct(
-        Printer $printer,
-        bool $checkExplicitMixed
+        private readonly Printer $printer,
+        private readonly bool $checkExplicitMixed,
     )
     {
-        $this->printer = $printer;
-        $this->checkExplicitMixed = $checkExplicitMixed;
     }
 
     public function getNodeType(): string
@@ -48,7 +41,7 @@ class ForbidMethodCallOnMixedRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($this->checkExplicitMixed) {
@@ -69,7 +62,7 @@ class ForbidMethodCallOnMixedRule implements Rule
      */
     private function checkCall(
         CallLike $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $caller = $node instanceof StaticCall ? $node->class : $node->var;
@@ -104,16 +97,11 @@ class ForbidMethodCallOnMixedRule implements Rule
      */
     private function getCallToken(CallLike $node): string
     {
-        switch (get_class($node)) {
-            case StaticCall::class:
-                return '::';
-
-            case MethodCall::class:
-                return $node->getAttribute('virtualNullsafeMethodCall') === true ? '?->' : '->';
-
-            default:
-                throw new LogicException('Unexpected node given: ' . get_class($node));
-        }
+        return match ($node::class) {
+            StaticCall::class => '::',
+            MethodCall::class => $node->getAttribute('virtualNullsafeMethodCall') === true ? '?->' : '->',
+            default => throw new LogicException('Unexpected node given: ' . $node::class),
+        };
     }
 
 }

--- a/src/Rule/ForbidNotNormalizedTypeRule.php
+++ b/src/Rule/ForbidNotNormalizedTypeRule.php
@@ -53,30 +53,18 @@ use function spl_object_id;
 class ForbidNotNormalizedTypeRule implements Rule
 {
 
-    private FileTypeMapper $fileTypeMapper;
-
-    private TypeNodeResolver $typeNodeResolver;
-
-    private Printer $phpParserPrinter;
-
-    private bool $checkDisjunctiveNormalForm;
-
     /**
      * @var array<int, true>
      */
     private array $processedDocComments = [];
 
     public function __construct(
-        FileTypeMapper $fileTypeMapper,
-        TypeNodeResolver $typeNodeResolver,
-        Printer $phpParserPrinter,
-        bool $checkDisjunctiveNormalForm
+        private readonly FileTypeMapper $fileTypeMapper,
+        private readonly TypeNodeResolver $typeNodeResolver,
+        private readonly Printer $phpParserPrinter,
+        private readonly bool $checkDisjunctiveNormalForm,
     )
     {
-        $this->fileTypeMapper = $fileTypeMapper;
-        $this->typeNodeResolver = $typeNodeResolver;
-        $this->phpParserPrinter = $phpParserPrinter;
-        $this->checkDisjunctiveNormalForm = $checkDisjunctiveNormalForm;
     }
 
     public function getNodeType(): string
@@ -89,7 +77,7 @@ class ForbidNotNormalizedTypeRule implements Rule
      */
     public function processNode(
         PhpParserNode $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($node instanceof FunctionLike) {
@@ -118,7 +106,7 @@ class ForbidNotNormalizedTypeRule implements Rule
      */
     private function checkCatchNativeType(
         Catch_ $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $multiTypeNode = new UnionType($node->types, $node->getAttributes());
@@ -130,7 +118,7 @@ class ForbidNotNormalizedTypeRule implements Rule
      */
     private function checkParamAndReturnAndThrowsPhpDoc(
         FunctionLike $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $errors = [];
@@ -164,7 +152,7 @@ class ForbidNotNormalizedTypeRule implements Rule
      */
     private function checkPropertyNativeType(
         Property $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $errors = [];
@@ -186,7 +174,7 @@ class ForbidNotNormalizedTypeRule implements Rule
      */
     private function checkParamAndReturnNativeType(
         FunctionLike $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $errors = [];
@@ -221,7 +209,7 @@ class ForbidNotNormalizedTypeRule implements Rule
      */
     private function checkPropertyPhpDoc(
         Property $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $errors = [];
@@ -250,7 +238,7 @@ class ForbidNotNormalizedTypeRule implements Rule
      */
     private function checkInlineVarDoc(
         PhpParserNode $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $docComment = $node->getDocComment();
@@ -290,7 +278,7 @@ class ForbidNotNormalizedTypeRule implements Rule
 
     private function resolvePhpDoc(
         PhpParserNode $node,
-        Scope $scope
+        Scope $scope,
     ): ?ResolvedPhpDocBlock
     {
         $docComment = $node->getDocComment();
@@ -324,7 +312,7 @@ class ForbidNotNormalizedTypeRule implements Rule
     public function processParamTags(
         PhpParserNode $sourceNode,
         array $paramTagValues,
-        NameScope $nameSpace
+        NameScope $nameSpace,
     ): array
     {
         $errors = [];
@@ -352,7 +340,7 @@ class ForbidNotNormalizedTypeRule implements Rule
     public function processVarTags(
         PhpParserNode $originalNode,
         array $varTagValues,
-        NameScope $nameSpace
+        NameScope $nameSpace,
     ): array
     {
         $errors = [];
@@ -384,7 +372,7 @@ class ForbidNotNormalizedTypeRule implements Rule
     public function processReturnTags(
         PhpParserNode $originalNode,
         array $returnTagValues,
-        NameScope $nameSpace
+        NameScope $nameSpace,
     ): array
     {
         $errors = [];
@@ -408,7 +396,7 @@ class ForbidNotNormalizedTypeRule implements Rule
     public function processThrowsTags(
         PhpParserNode $originalNode,
         array $throwsTagValues,
-        NameScope $nameSpace
+        NameScope $nameSpace,
     ): array
     {
         $thrownTypes = [];
@@ -440,7 +428,7 @@ class ForbidNotNormalizedTypeRule implements Rule
      */
     private function extractUnionAndIntersectionPhpDocTypeNodes(
         TypeNode $typeNode,
-        int $line
+        int $line,
     ): array
     {
         /** @var list<UnionTypeNode|IntersectionTypeNode> $nodes */
@@ -498,7 +486,7 @@ class ForbidNotNormalizedTypeRule implements Rule
      */
     private function traversePhpDocTypeNode(
         $type,
-        callable $callback
+        callable $callback,
     ): void
     {
         if (is_array($type)) {
@@ -523,7 +511,7 @@ class ForbidNotNormalizedTypeRule implements Rule
     private function processMultiTypePhpParserNode(
         ComplexType $multiTypeNode,
         Scope $scope,
-        string $identification
+        string $identification,
     ): array
     {
         $innerTypeNodes = array_values($multiTypeNode->types);
@@ -577,7 +565,7 @@ class ForbidNotNormalizedTypeRule implements Rule
     private function processMultiTypePhpDocNode(
         TypeNode $multiTypeNode,
         NameScope $nameSpace,
-        ?string $identification
+        ?string $identification,
     ): array
     {
         $errors = [];
@@ -655,7 +643,7 @@ class ForbidNotNormalizedTypeRule implements Rule
 
     private function getPhpDocLine(
         PhpParserNode $node,
-        PhpDocRootNode $phpDocNode
+        PhpDocRootNode $phpDocNode,
     ): int
     {
         /** @var int|null $phpDocTagLine */

--- a/src/Rule/ForbidNullInAssignOperationsRule.php
+++ b/src/Rule/ForbidNullInAssignOperationsRule.php
@@ -23,7 +23,6 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\TypeCombinator;
-use function get_class;
 use function in_array;
 
 /**
@@ -35,16 +34,10 @@ class ForbidNullInAssignOperationsRule implements Rule
     private const DEFAULT_BLACKLIST = ['??='];
 
     /**
-     * @var string[]
-     */
-    private array $blacklist;
-
-    /**
      * @param string[] $blacklist
      */
-    public function __construct(array $blacklist = self::DEFAULT_BLACKLIST)
+    public function __construct(private readonly array $blacklist = self::DEFAULT_BLACKLIST)
     {
-        $this->blacklist = $blacklist;
     }
 
     public function getNodeType(): string
@@ -58,7 +51,7 @@ class ForbidNullInAssignOperationsRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $exprType = $scope->getType($node->expr);
@@ -128,7 +121,7 @@ class ForbidNullInAssignOperationsRule implements Rule
             return '&=';
         }
 
-        throw new LogicException('Unexpected AssignOp child: ' . get_class($node));
+        throw new LogicException('Unexpected AssignOp child: ' . $node::class);
     }
 
 }

--- a/src/Rule/ForbidNullInBinaryOperationsRule.php
+++ b/src/Rule/ForbidNullInBinaryOperationsRule.php
@@ -21,16 +21,10 @@ class ForbidNullInBinaryOperationsRule implements Rule
     private const DEFAULT_BLACKLIST = ['===', '!==', '??'];
 
     /**
-     * @var list<string>
-     */
-    private array $blacklist;
-
-    /**
      * @param list<string> $blacklist
      */
-    public function __construct(array $blacklist = self::DEFAULT_BLACKLIST)
+    public function __construct(private readonly array $blacklist = self::DEFAULT_BLACKLIST)
     {
-        $this->blacklist = $blacklist;
     }
 
     public function getNodeType(): string
@@ -44,7 +38,7 @@ class ForbidNullInBinaryOperationsRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (in_array($node->getOperatorSigil(), $this->blacklist, true)) {

--- a/src/Rule/ForbidNullInInterpolatedStringRule.php
+++ b/src/Rule/ForbidNullInInterpolatedStringRule.php
@@ -18,11 +18,8 @@ use PHPStan\Type\TypeCombinator;
 class ForbidNullInInterpolatedStringRule implements Rule
 {
 
-    private Printer $printer;
-
-    public function __construct(Printer $printer)
+    public function __construct(private readonly Printer $printer)
     {
-        $this->printer = $printer;
     }
 
     public function getNodeType(): string
@@ -36,7 +33,7 @@ class ForbidNullInInterpolatedStringRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $errors = [];

--- a/src/Rule/ForbidPhpDocNullabilityMismatchWithNativeTypehintRule.php
+++ b/src/Rule/ForbidPhpDocNullabilityMismatchWithNativeTypehintRule.php
@@ -27,13 +27,10 @@ use function is_string;
 class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
 {
 
-    private FileTypeMapper $fileTypeMapper;
-
     public function __construct(
-        FileTypeMapper $fileTypeMapper
+        private readonly FileTypeMapper $fileTypeMapper,
     )
     {
-        $this->fileTypeMapper = $fileTypeMapper;
     }
 
     public function getNodeType(): string
@@ -46,7 +43,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($node instanceof FunctionLike) {
@@ -68,7 +65,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
      */
     private function checkReturnTypes(
         FunctionLike $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $phpDocReturnType = $this->getFunctionPhpDocReturnType($node, $scope);
@@ -82,7 +79,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
      */
     private function checkPropertyTypes(
         Property $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $phpDocReturnType = $this->getPropertyPhpDocType($node, $scope);
@@ -96,7 +93,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
      */
     private function checkParamTypes(
         FunctionLike $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $errors = [];
@@ -125,7 +122,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
      */
     private function getParamOrPropertyNativeType(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): ?Type
     {
         if ($node->type === null) {
@@ -137,7 +134,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
 
     private function getFunctionNativeReturnType(
         FunctionLike $node,
-        Scope $scope
+        Scope $scope,
     ): ?Type
     {
         if ($node->getReturnType() === null) {
@@ -149,7 +146,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
 
     private function getPropertyPhpDocType(
         Property $node,
-        Scope $scope
+        Scope $scope,
     ): ?Type
     {
         $resolvedPhpDoc = $this->resolvePhpDoc($node, $scope);
@@ -169,7 +166,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
 
     private function getFunctionPhpDocReturnType(
         FunctionLike $node,
-        Scope $scope
+        Scope $scope,
     ): ?Type
     {
         $resolvedPhpDoc = $this->resolvePhpDoc($node, $scope);
@@ -189,7 +186,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
 
     private function resolvePhpDoc(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): ?ResolvedPhpDocBlock
     {
         $docComment = $node->getDocComment();
@@ -210,7 +207,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
     private function getPhpDocParamType(
         FunctionLike $node,
         Scope $scope,
-        string $parameterName
+        string $parameterName,
     ): ?Type
     {
         $resolvedPhpDoc = $this->resolvePhpDoc($node, $scope);
@@ -237,7 +234,7 @@ class ForbidPhpDocNullabilityMismatchWithNativeTypehintRule implements Rule
         ?Type $phpDocReturnType,
         ?Type $nativeReturnType,
         Scope $scope,
-        string $phpDocIdentification
+        string $phpDocIdentification,
     ): array
     {
         if ($phpDocReturnType === null || $nativeReturnType === null) {

--- a/src/Rule/ForbidProtectedEnumMethodRule.php
+++ b/src/Rule/ForbidProtectedEnumMethodRule.php
@@ -26,7 +26,7 @@ class ForbidProtectedEnumMethodRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($scope->getClassReflection() === null || !$scope->getClassReflection()->isEnum()) {

--- a/src/Rule/ForbidReturnInConstructorRule.php
+++ b/src/Rule/ForbidReturnInConstructorRule.php
@@ -27,7 +27,7 @@ class ForbidReturnInConstructorRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($scope->isInAnonymousFunction()) {

--- a/src/Rule/ForbidReturnValueInYieldingMethodRule.php
+++ b/src/Rule/ForbidReturnValueInYieldingMethodRule.php
@@ -21,11 +21,8 @@ use function in_array;
 class ForbidReturnValueInYieldingMethodRule implements Rule
 {
 
-    private bool $reportRegardlessOfReturnType;
-
-    public function __construct(bool $reportRegardlessOfReturnType)
+    public function __construct(private readonly bool $reportRegardlessOfReturnType)
     {
-        $this->reportRegardlessOfReturnType = $reportRegardlessOfReturnType;
     }
 
     public function getNodeType(): string
@@ -39,7 +36,7 @@ class ForbidReturnValueInYieldingMethodRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$node->getStatementResult()->hasYield()) {
@@ -82,7 +79,7 @@ class ForbidReturnValueInYieldingMethodRule implements Rule
 
     private function getReturnType(
         ReturnStatementsNode $node,
-        Scope $scope
+        Scope $scope,
     ): Type
     {
         $methodReflection = $scope->getFunction();

--- a/src/Rule/ForbidUnsafeArrayKeyRule.php
+++ b/src/Rule/ForbidUnsafeArrayKeyRule.php
@@ -22,17 +22,11 @@ use PHPStan\Type\VerbosityLevel;
 class ForbidUnsafeArrayKeyRule implements Rule
 {
 
-    private bool $reportMixed;
-
-    private bool $reportInsideIsset;
-
     public function __construct(
-        bool $reportMixed,
-        bool $reportInsideIsset
+        private readonly bool $reportMixed,
+        private readonly bool $reportInsideIsset,
     )
     {
-        $this->reportMixed = $reportMixed;
-        $this->reportInsideIsset = $reportInsideIsset;
     }
 
     public function getNodeType(): string
@@ -45,7 +39,7 @@ class ForbidUnsafeArrayKeyRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($node instanceof ArrayItem && $node->key !== null) {
@@ -97,7 +91,7 @@ class ForbidUnsafeArrayKeyRule implements Rule
      */
     private function containsOnlyTypes(
         Type $checkedType,
-        array $allowedTypes
+        array $allowedTypes,
     ): bool
     {
         $allowedType = TypeCombinator::union(...$allowedTypes);

--- a/src/Rule/ForbidUnsetClassFieldRule.php
+++ b/src/Rule/ForbidUnsetClassFieldRule.php
@@ -27,7 +27,7 @@ class ForbidUnsetClassFieldRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         foreach ($node->vars as $item) {

--- a/src/Rule/ForbidUnusedClosureParametersRule.php
+++ b/src/Rule/ForbidUnusedClosureParametersRule.php
@@ -38,7 +38,7 @@ final class ForbidUnusedClosureParametersRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($node instanceof ArrowFunction) {
@@ -110,7 +110,7 @@ final class ForbidUnusedClosureParametersRule implements Rule
      */
     private function getTrailingUnusedParameterNames(
         array $params,
-        array $referencedVariables
+        array $referencedVariables,
     ): array
     {
         for ($i = count($params) - 1; $i >= 0; $i--) {

--- a/src/Rule/ForbidUnusedExceptionRule.php
+++ b/src/Rule/ForbidUnusedExceptionRule.php
@@ -22,11 +22,8 @@ use Throwable;
 class ForbidUnusedExceptionRule implements Rule
 {
 
-    private Printer $printer;
-
-    public function __construct(Printer $printer)
+    public function __construct(private readonly Printer $printer)
     {
-        $this->printer = $printer;
     }
 
     public function getNodeType(): string
@@ -40,7 +37,7 @@ class ForbidUnusedExceptionRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($node instanceof MethodCall || $node instanceof StaticCall) {
@@ -60,7 +57,7 @@ class ForbidUnusedExceptionRule implements Rule
      */
     private function processCall(
         CallLike $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$this->isException($node, $scope)) {
@@ -82,7 +79,7 @@ class ForbidUnusedExceptionRule implements Rule
      */
     private function processNew(
         New_ $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$this->isException($node, $scope)) {
@@ -101,7 +98,7 @@ class ForbidUnusedExceptionRule implements Rule
 
     private function isException(
         Expr $node,
-        Scope $scope
+        Scope $scope,
     ): bool
     {
         $type = $scope->getType($node);

--- a/src/Rule/ForbidUnusedMatchResultRule.php
+++ b/src/Rule/ForbidUnusedMatchResultRule.php
@@ -31,7 +31,7 @@ class ForbidUnusedMatchResultRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $returnedTypes = [];

--- a/src/Rule/ForbidUselessNullableReturnRule.php
+++ b/src/Rule/ForbidUselessNullableReturnRule.php
@@ -34,7 +34,7 @@ class ForbidUselessNullableReturnRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if ($node instanceof PropertyHookReturnStatementsNode) {

--- a/src/Rule/ForbidVariableTypeOverwritingRule.php
+++ b/src/Rule/ForbidVariableTypeOverwritingRule.php
@@ -40,7 +40,7 @@ class ForbidVariableTypeOverwritingRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         if (!$node->var instanceof Variable) {

--- a/src/Rule/RequirePreviousExceptionPassRule.php
+++ b/src/Rule/RequirePreviousExceptionPassRule.php
@@ -36,17 +36,11 @@ use function is_string;
 class RequirePreviousExceptionPassRule implements Rule
 {
 
-    private Printer $printer;
-
-    private bool $reportEvenIfExceptionIsNotAcceptableByRethrownOne;
-
     public function __construct(
-        Printer $printer,
-        bool $reportEvenIfExceptionIsNotAcceptableByRethrownOne = false
+        private readonly Printer $printer,
+        private readonly bool $reportEvenIfExceptionIsNotAcceptableByRethrownOne = false,
     )
     {
-        $this->printer = $printer;
-        $this->reportEvenIfExceptionIsNotAcceptableByRethrownOne = $reportEvenIfExceptionIsNotAcceptableByRethrownOne;
     }
 
     public function getNodeType(): string
@@ -60,7 +54,7 @@ class RequirePreviousExceptionPassRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $errors = [];
@@ -109,7 +103,7 @@ class RequirePreviousExceptionPassRule implements Rule
         ?string $caughtExceptionVariableName,
         Type $caughtExceptionType,
         CallLike $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $passed = false;
@@ -163,7 +157,7 @@ class RequirePreviousExceptionPassRule implements Rule
      */
     private function getCallLikeParameters(
         CallLike $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $methodReflection = null;
@@ -197,7 +191,7 @@ class RequirePreviousExceptionPassRule implements Rule
     private function getCaughtExceptionType(
         array $exceptionNames,
         Scope $scope,
-        Type $exceptionTypesCaughtInPreviousCatches
+        Type $exceptionTypesCaughtInPreviousCatches,
     ): Type
     {
         $classes = [];

--- a/src/Rule/UselessPrivatePropertyDefaultValueRule.php
+++ b/src/Rule/UselessPrivatePropertyDefaultValueRule.php
@@ -29,7 +29,7 @@ class UselessPrivatePropertyDefaultValueRule implements Rule
      */
     public function processNode(
         Node $node,
-        Scope $scope
+        Scope $scope,
     ): array
     {
         $classReflection = $scope->getClassReflection();

--- a/tests/AllRulesInConfigTest.php
+++ b/tests/AllRulesInConfigTest.php
@@ -6,7 +6,6 @@ use DirectoryIterator;
 use PHPStan\Testing\PHPStanTestCase;
 use function array_keys;
 use function array_merge;
-use function get_class;
 use function implode;
 use function str_replace;
 
@@ -46,7 +45,7 @@ class AllRulesInConfigTest extends PHPStanTestCase
         $registeredRules = self::getContainer()->getServicesByTag('phpstan.rules.rule');
 
         foreach ($registeredRules as $registeredRule) {
-            unset($existingRuleClassNames[get_class($registeredRule)]);
+            unset($existingRuleClassNames[$registeredRule::class]);
         }
 
         if ($existingRuleClassNames !== []) {

--- a/tests/Rule/BackedEnumGenericsRuleTest.php
+++ b/tests/Rule/BackedEnumGenericsRuleTest.php
@@ -5,7 +5,6 @@ namespace ShipMonk\PHPStan\Rule;
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
 use function array_merge;
-use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<BackedEnumGenericsRule>
@@ -31,10 +30,6 @@ class BackedEnumGenericsRuleTest extends RuleTestCase
 
     public function testClass(): void
     {
-        if (PHP_VERSION_ID < 80_100) {
-            self::markTestSkipped('Requires PHP 8.1');
-        }
-
         $this->analyseFile(__DIR__ . '/data/BackedEnumGenericsRule/code.php');
     }
 

--- a/tests/Rule/EnforceEnumMatchRuleTest.php
+++ b/tests/Rule/EnforceEnumMatchRuleTest.php
@@ -4,7 +4,6 @@ namespace ShipMonk\PHPStan\Rule;
 
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
-use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<EnforceEnumMatchRule>
@@ -19,10 +18,6 @@ class EnforceEnumMatchRuleTest extends RuleTestCase
 
     public function testRule(): void
     {
-        if (PHP_VERSION_ID < 80_100) {
-            self::markTestSkipped('Requires PHP 8.1');
-        }
-
         $this->analyseFile(
             __DIR__ . '/data/EnforceEnumMatchRule/code.php',
         );

--- a/tests/Rule/EnforceNativeReturnTypehintRuleTest.php
+++ b/tests/Rule/EnforceNativeReturnTypehintRuleTest.php
@@ -23,16 +23,12 @@ class EnforceNativeReturnTypehintRuleTest extends RuleTestCase
         return new EnforceNativeReturnTypehintRule(
             self::getContainer()->getByType(FileTypeMapper::class),
             $this->phpVersion,
-            true,
+            treatPhpDocTypesAsCertain: true,
         );
     }
 
     public function testEnum(): void
     {
-        if (PHP_VERSION_ID < 80_100) {
-            self::markTestSkipped('Requires PHP 8.1');
-        }
-
         $this->phpVersion = self::getContainer()->getByType(PhpVersion::class);
         $this->analyseFile(__DIR__ . '/data/EnforceNativeReturnTypehintRule/code-enum.php');
     }

--- a/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
+++ b/tests/Rule/EnforceReadonlyPublicPropertyRuleTest.php
@@ -6,7 +6,6 @@ use LogicException;
 use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
-use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<EnforceReadonlyPublicPropertyRule>
@@ -36,10 +35,6 @@ class EnforceReadonlyPublicPropertyRuleTest extends RuleTestCase
 
     public function testPhp84(): void
     {
-        if (PHP_VERSION_ID < 8_00_00) {
-            self::markTestSkipped('PHP7 parser fails with property hooks');
-        }
-
         $this->excludePropertyWithDefaultValue = false;
         $this->phpVersion = $this->createPhpVersion(80_400);
         $this->analyseFile(__DIR__ . '/data/EnforceReadonlyPublicPropertyRule/code-84.php');

--- a/tests/Rule/ForbidCheckedExceptionInCallableRuleTest.php
+++ b/tests/Rule/ForbidCheckedExceptionInCallableRuleTest.php
@@ -62,7 +62,7 @@ class ForbidCheckedExceptionInCallableRuleTest extends RuleTestCase
      */
     public function test(
         bool $implicitThrows,
-        array $checkedExceptions
+        array $checkedExceptions,
     ): void
     {
         self::$implicitThrows = $implicitThrows;

--- a/tests/Rule/ForbidEnumInFunctionArgumentsRuleTest.php
+++ b/tests/Rule/ForbidEnumInFunctionArgumentsRuleTest.php
@@ -5,7 +5,6 @@ namespace ShipMonk\PHPStan\Rule;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
-use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ForbidEnumInFunctionArgumentsRule>
@@ -22,10 +21,6 @@ class ForbidEnumInFunctionArgumentsRuleTest extends RuleTestCase
 
     public function test(): void
     {
-        if (PHP_VERSION_ID < 80_100) {
-            self::markTestSkipped('Requires PHP 8.1');
-        }
-
         $this->analyseFile(__DIR__ . '/data/ForbidEnumInFunctionArgumentsRule/code.php');
     }
 

--- a/tests/Rule/ForbidMatchDefaultArmForEnumsRuleTest.php
+++ b/tests/Rule/ForbidMatchDefaultArmForEnumsRuleTest.php
@@ -4,7 +4,6 @@ namespace ShipMonk\PHPStan\Rule;
 
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
-use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ForbidMatchDefaultArmForEnumsRule>
@@ -19,10 +18,6 @@ class ForbidMatchDefaultArmForEnumsRuleTest extends RuleTestCase
 
     public function test(): void
     {
-        if (PHP_VERSION_ID < 80_100) {
-            self::markTestSkipped('Requires PHP 8.1');
-        }
-
         $this->analyseFile(__DIR__ . '/data/ForbidMatchDefaultArmForEnumsRule/code.php');
     }
 

--- a/tests/Rule/ForbidProtectedEnumMethodRuleTest.php
+++ b/tests/Rule/ForbidProtectedEnumMethodRuleTest.php
@@ -4,7 +4,6 @@ namespace ShipMonk\PHPStan\Rule;
 
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
-use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ForbidProtectedEnumMethodRule>
@@ -19,10 +18,6 @@ class ForbidProtectedEnumMethodRuleTest extends RuleTestCase
 
     public function test(): void
     {
-        if (PHP_VERSION_ID < 80_100) {
-            self::markTestSkipped('Requires PHP 8.1');
-        }
-
         $this->analyseFile(__DIR__ . '/data/ForbidProtectedEnumMethodRule/code.php');
     }
 

--- a/tests/Rule/ForbidUnsafeArrayKeyRuleTest.php
+++ b/tests/Rule/ForbidUnsafeArrayKeyRuleTest.php
@@ -6,7 +6,6 @@ use LogicException;
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\Rule\ForbidUnsafeArrayKeyRule;
 use ShipMonk\PHPStan\RuleTestCase;
-use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ForbidUnsafeArrayKeyRule>
@@ -36,10 +35,6 @@ class ForbidUnsafeArrayKeyRuleTest extends RuleTestCase
 
     public function testStrict(): void
     {
-        if (PHP_VERSION_ID < 8_00_00) {
-            self::markTestSkipped('Test is for PHP 8.0+, we are using native mixed type there');
-        }
-
         $this->checkMixed = true;
         $this->checkInsideIsset = true;
         $this->analyseFile(__DIR__ . '/data/ForbidUnsafeArrayKeyRule/default.php');
@@ -47,10 +42,6 @@ class ForbidUnsafeArrayKeyRuleTest extends RuleTestCase
 
     public function testLessStrict(): void
     {
-        if (PHP_VERSION_ID < 8_00_00) {
-            self::markTestSkipped('Test is for PHP 8.0+, we are using native mixed type there');
-        }
-
         $this->checkMixed = false;
         $this->checkInsideIsset = false;
         $this->analyseFile(__DIR__ . '/data/ForbidUnsafeArrayKeyRule/less-strict.php');

--- a/tests/Rule/ForbidUselessNullableReturnRuleTest.php
+++ b/tests/Rule/ForbidUselessNullableReturnRuleTest.php
@@ -4,7 +4,6 @@ namespace ShipMonk\PHPStan\Rule;
 
 use PHPStan\Rules\Rule;
 use ShipMonk\PHPStan\RuleTestCase;
-use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ForbidUselessNullableReturnRule>
@@ -24,10 +23,6 @@ class ForbidUselessNullableReturnRuleTest extends RuleTestCase
 
     public function testPropertyHooks(): void
     {
-        if (PHP_VERSION_ID < 8_00_00) {
-            self::markTestSkipped('PHP7 parser fails with property hooks');
-        }
-
         $this->analyseFile(__DIR__ . '/data/ForbidUselessNullableReturnRule/code-hook.php');
     }
 

--- a/tests/RuleTestCase.php
+++ b/tests/RuleTestCase.php
@@ -18,7 +18,7 @@ abstract class RuleTestCase extends ShipMonkDevRuleTestCase
      */
     protected function analyseFile(
         $files,
-        bool $autofix = false
+        bool $autofix = false,
     ): void
     {
         $this->analyzeFiles(is_array($files) ? $files : [$files], $autofix);

--- a/tests/ThrowingSourceLocator.php
+++ b/tests/ThrowingSourceLocator.php
@@ -14,7 +14,7 @@ class ThrowingSourceLocator implements SourceLocator
 
     public function locateIdentifier(
         Reflector $reflector,
-        Identifier $identifier
+        Identifier $identifier,
     ): ?Reflection // @phpstan-ignore return.internalInterface
     {
         throw new LogicException('Reflection must not be called during rule construction');
@@ -25,7 +25,7 @@ class ThrowingSourceLocator implements SourceLocator
      */
     public function locateIdentifiersByType(
         Reflector $reflector,
-        IdentifierType $identifierType
+        IdentifierType $identifierType,
     ): array // @phpstan-ignore return.internalInterface
     {
         throw new LogicException('Reflection must not be called during rule construction');


### PR DESCRIPTION
## Summary
- Bumps PHP requirement to `^8.1` (composer.json, phpstan/phpcs `phpVersion`, CI matrix).
- Modernizes source and tests to use PHP 8.0/8.1 features that were previously avoided to keep PHP 7.4 compatibility.

## Config changes
- `composer.json`: `"php": "^7.4 || ^8.0"` → `"^8.1"`
- `phpstan.neon.dist`: `phpVersion.min: 70400` → `80100`; enable `enforceClosureParamNativeTypehint`; drop obsolete BC ignores (`BackedEnum not found`, `isEnum() always false`)
- `phpcs.xml.dist`: `php_version: 70400` → `80100`; drop `DisallowTrailingCommaInDeclaration` override (trailing commas are now required by the default coding standard)
- `.github/workflows/checks.yml`: drop `7.4` / `8.0` from test matrix; remove the `composer remove shipmonk/coverage-guard` workaround (it requires PHP 8.1+ — same as us now)

## Source modernization
- Constructor property promotion with `private readonly` across rules (skipped where the constructor has mixed responsibilities, e.g. `ForbidCustomFunctionsRule` validates and transforms its input)
- `switch (\$node::class)` → `match` expressions (`ForbidMethodCallOnMixedRule`, `ForbidFetchOnMixedRule`, `ForbidIncrementDecrementOnNonIntegerRule`)
- `strpos(...) !== false` → `str_contains(...)` (`ForbidCheckedExceptionInCallableRule`)
- `substr_compare(\$a, \$b, -strlen(\$b)) === 0` → `str_ends_with(\$a, \$b)` (`ClassSuffixNamingRule`)
- First-class callable syntax `\$this->normalizeArgumentIndexes(...)` in `ForbidCheckedExceptionInCallableRule`
- `phpcbf` added trailing commas to all multi-line function declarations (now required)

## Test modernization
- Removed `PHP_VERSION_ID < 80100` / `< 80000` guards that are now always satisfied (kept `< 80200` and `< 80400` checks that are still relevant)
- `get_class(\$x)` → `\$x::class` in `AllRulesInConfigTest`

## Test plan
- [x] `composer check` passes (composer normalize, phpcs, phpstan, phpunit, coverage-guard, dependency-analyser, name-collision-detector, inline-ignore verifier)
- [x] CI matrix passes across PHP 8.1 - 8.5 on Linux and Windows