### PR TITLE
Use `never` return type in ThrowingSourceLocator

### DIFF
--- a/tests/ThrowingSourceLocator.php
+++ b/tests/ThrowingSourceLocator.php
@@ -5,7 +5,6 @@ namespace ShipMonk\PHPStan;
 use LogicException;
 use PHPStan\BetterReflection\Identifier\Identifier;
 use PHPStan\BetterReflection\Identifier\IdentifierType;
-use PHPStan\BetterReflection\Reflection\Reflection;
 use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\BetterReflection\SourceLocator\Type\SourceLocator;
 
@@ -15,18 +14,15 @@ class ThrowingSourceLocator implements SourceLocator
     public function locateIdentifier(
         Reflector $reflector,
         Identifier $identifier,
-    ): ?Reflection // @phpstan-ignore return.internalInterface
+    ): never
     {
         throw new LogicException('Reflection must not be called during rule construction');
     }
 
-    /**
-     * @return list<Reflection>
-     */
     public function locateIdentifiersByType(
         Reflector $reflector,
         IdentifierType $identifierType,
-    ): array // @phpstan-ignore return.internalInterface
+    ): never
     {
         throw new LogicException('Reflection must not be called during rule construction');
     }


### PR DESCRIPTION
## Summary
- Now that PHP < 8.1 is dropped (#361), `: never` is available, so the throw-only methods in `ThrowingSourceLocator` can use it.
- Removes both `@phpstan-ignore return.internalInterface` annotations, the unused `Reflection` import, and the `@return list<Reflection>` PHPDoc.

Follow-up to discussion on #359.

## Test plan
- [x] `composer check:types`
- [x] `composer check:cs`
- [x] `composer check:ignores`
- [x] PHPUnit suite

Co-Authored-By: Claude Code