### PR TITLE
Adopt new shipmonk/coding-standard custom sniffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpstan/phpstan-phpunit": "^2.0.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",
         "phpunit/phpunit": "^10.5.46",
-        "shipmonk/coding-standard": "dev-add-generic-custom-sniffs",
+        "shipmonk/coding-standard": "^0.3.0",
         "shipmonk/composer-dependency-analyser": "^1.8.1",
         "shipmonk/coverage-guard": "^1.0.0",
         "shipmonk/dead-code-detector": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpstan/phpstan-phpunit": "^2.0.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",
         "phpunit/phpunit": "^10.5.46",
-        "shipmonk/coding-standard": "^0.2.0",
+        "shipmonk/coding-standard": "dev-add-generic-custom-sniffs",
         "shipmonk/composer-dependency-analyser": "^1.8.1",
         "shipmonk/coverage-guard": "^1.0.0",
         "shipmonk/dead-code-detector": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3a6ae890681f79796bfb6d571fd6cab",
+    "content-hash": "82c83b733a63df8eb75144d71525e416",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -2861,21 +2861,21 @@
         },
         {
             "name": "shipmonk/coding-standard",
-            "version": "dev-add-generic-custom-sniffs",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844"
+                "reference": "15182bf6b0e17682990c049dd17f593d3235ec62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/556e3d2499dec123904ec09d90e5d1d8a2b36844",
-                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/15182bf6b0e17682990c049dd17f593d3235ec62",
+                "reference": "15182bf6b0e17682990c049dd17f593d3235ec62",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.4 || ^8.0",
+                "php": "^8.1",
                 "slevomat/coding-standard": "^8.28.0",
                 "squizlabs/php_codesniffer": "^4.0.1"
             },
@@ -2886,9 +2886,9 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
+                "phpunit/phpunit": "^10.5.62",
                 "shipmonk/composer-dependency-analyser": "^1.8",
-                "shipmonk/dead-code-detector": "^0.12",
+                "shipmonk/dead-code-detector": "^1.0",
                 "shipmonk/name-collision-detector": "^2.1",
                 "shipmonk/phpstan-rules": "^4.1"
             },
@@ -2905,9 +2905,9 @@
             "description": "PHP Coding Standard used in ShipMonk",
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
-                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
+                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.3.0"
             },
-            "time": "2026-06-22T07:30:14+00:00"
+            "time": "2026-06-23T07:41:40+00:00"
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
@@ -3431,9 +3431,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "shipmonk/coding-standard": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f74332d5e7fa79091dcb89ac9d6331f",
+    "content-hash": "a3a6ae890681f79796bfb6d571fd6cab",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -2861,21 +2861,23 @@
         },
         {
             "name": "shipmonk/coding-standard",
-            "version": "0.2.4",
+            "version": "dev-add-generic-custom-sniffs",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "ca7fa071f5943d87f67e791fe36a691a36d10275"
+                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/ca7fa071f5943d87f67e791fe36a691a36d10275",
-                "reference": "ca7fa071f5943d87f67e791fe36a691a36d10275",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/556e3d2499dec123904ec09d90e5d1d8a2b36844",
+                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844",
                 "shasum": ""
             },
             "require": {
+                "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
-                "slevomat/coding-standard": "^8.28.0"
+                "slevomat/coding-standard": "^8.28.0",
+                "squizlabs/php_codesniffer": "^4.0.1"
             },
             "require-dev": {
                 "editorconfig-checker/editorconfig-checker": "^10.6",
@@ -2893,7 +2895,7 @@
             "type": "phpcodesniffer-standard",
             "autoload": {
                 "psr-4": {
-                    "ShipMonk\\CodingStandard\\": "ShipMonkCodingStandard/"
+                    "ShipMonkCodingStandard\\": "ShipMonkCodingStandard/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2903,9 +2905,9 @@
             "description": "PHP Coding Standard used in ShipMonk",
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
-                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.2.4"
+                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
             },
-            "time": "2026-03-16T16:23:10+00:00"
+            "time": "2026-06-22T07:30:14+00:00"
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
@@ -3429,7 +3431,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "shipmonk/coding-standard": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Rule/ForbidArithmeticOperationOnNonNumberRule.php
+++ b/src/Rule/ForbidArithmeticOperationOnNonNumberRule.php
@@ -119,8 +119,8 @@ class ForbidArithmeticOperationOnNonNumberRule implements Rule
         }
 
         if (
-            $operator === '%' &&
-            (!$leftType->isInteger()->yes() || !$rightType->isInteger()->yes())
+            $operator === '%'
+            && (!$leftType->isInteger()->yes() || !$rightType->isInteger()->yes())
         ) {
             return $this->buildBinaryErrors($operator, 'non-integer', $leftType, $rightType);
         }


### PR DESCRIPTION
Bumps `shipmonk/coding-standard` to `^0.3.0`, which adds the new ShipMonk custom sniffs, and applies the auto-fixable results (`phpcbf`). All violations were auto-fixable; no manual changes.

Co-Authored-By: Claude Code