### PR TITLE
Update coverage-guard to 1.1.0, ignore LogicException throws in coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpunit/phpunit": "^10.5.46",
         "shipmonk/coding-standard": "^0.3.0",
         "shipmonk/composer-dependency-analyser": "^1.8.1",
-        "shipmonk/coverage-guard": "^1.0.0",
+        "shipmonk/coverage-guard": "^1.1.0",
         "shipmonk/dead-code-detector": "^1.0",
         "shipmonk/name-collision-detector": "^2.1.1",
         "shipmonk/phpstan-dev": "^0.1.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82c83b733a63df8eb75144d71525e416",
+    "content-hash": "e51b5a136a8daf2818743c856929b087",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -2977,16 +2977,16 @@
         },
         {
             "name": "shipmonk/coverage-guard",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coverage-guard.git",
-                "reference": "8ca675c13740c0d83fe32af979cd0afc934216de"
+                "reference": "b969686103cd4b3eae85558b34898ef29535f2f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coverage-guard/zipball/8ca675c13740c0d83fe32af979cd0afc934216de",
-                "reference": "8ca675c13740c0d83fe32af979cd0afc934216de",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coverage-guard/zipball/b969686103cd4b3eae85558b34898ef29535f2f0",
+                "reference": "b969686103cd4b3eae85558b34898ef29535f2f0",
                 "shasum": ""
             },
             "require": {
@@ -2996,17 +2996,17 @@
             "require-dev": {
                 "editorconfig-checker/editorconfig-checker": "10.7.0",
                 "ergebnis/composer-normalize": "2.48.2",
-                "phpstan/phpstan": "2.1.32",
-                "phpstan/phpstan-phpunit": "2.0.8",
-                "phpstan/phpstan-strict-rules": "2.0.7",
+                "phpstan/phpstan": "2.2.0",
+                "phpstan/phpstan-phpunit": "2.0.16",
+                "phpstan/phpstan-strict-rules": "2.0.11",
                 "phpunit/php-code-coverage": "^10.1",
                 "phpunit/phpunit": "~10.5.58",
                 "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-                "shipmonk/coding-standard": "^0.2.0",
+                "shipmonk/coding-standard": "^0.2.4",
                 "shipmonk/composer-dependency-analyser": "1.8.4",
-                "shipmonk/dead-code-detector": "0.14.0",
+                "shipmonk/dead-code-detector": "^1.0",
                 "shipmonk/name-collision-detector": "2.1.1",
-                "shipmonk/phpstan-rules": "4.3.0"
+                "shipmonk/phpstan-rules": "4.3.6"
             },
             "bin": [
                 "bin/coverage-guard"
@@ -3031,9 +3031,9 @@
             ],
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coverage-guard/issues",
-                "source": "https://github.com/shipmonk-rnd/coverage-guard/tree/1.0.2"
+                "source": "https://github.com/shipmonk-rnd/coverage-guard/tree/1.1.0"
             },
-            "time": "2026-01-02T13:56:38+00:00"
+            "time": "2026-07-17T10:37:46+00:00"
         },
         {
             "name": "shipmonk/dead-code-detector",

--- a/coverage-guard.php
+++ b/coverage-guard.php
@@ -1,6 +1,7 @@
 <?php
 
 use ShipMonk\CoverageGuard\Config;
+use ShipMonk\CoverageGuard\Excluder\IgnoreThrowNewExceptionLineExcluder;
 use ShipMonk\CoverageGuard\Rule\EnforceCoverageForMethodsRule;
 
 $config = new Config();
@@ -8,5 +9,6 @@ $config->addRule(new EnforceCoverageForMethodsRule(
     requiredCoveragePercentage: 70,
     minExecutableLines: 5,
 ));
+$config->addExecutableLineExcluder(new IgnoreThrowNewExceptionLineExcluder([LogicException::class]));
 
 return $config;


### PR DESCRIPTION
Updates `shipmonk/coverage-guard` to `^1.1.0` and adopts the new native `ExecutableLineExcluder` introduced in that release:

- `throw new LogicException(...)` lines are no longer counted as executable for coverage enforcement (`IgnoreThrowNewExceptionLineExcluder`)

Verified locally: `composer check:coverage` passes.

Co-Authored-By: Claude Code

https://claude.ai/code/session_01YBrus7vYD8XFs8BXtoW6Eo
